### PR TITLE
New permissions system (fixup)

### DIFF
--- a/app/src/main/java/at/bitfire/icsdroid/PermissionUtils.kt
+++ b/app/src/main/java/at/bitfire/icsdroid/PermissionUtils.kt
@@ -1,0 +1,22 @@
+package at.bitfire.icsdroid
+
+import android.Manifest
+import android.widget.Toast
+import androidx.activity.result.ActivityResultLauncher
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.appcompat.app.AppCompatActivity
+
+class PermissionUtils(val activity: AppCompatActivity) {
+
+    fun getCalendarPermissionRequestLauncher(): ActivityResultLauncher<Array<String>> {
+        return activity.registerForActivityResult(
+            ActivityResultContracts.RequestMultiplePermissions()
+        ) { permissions ->
+            if (permissions.get(Manifest.permission.READ_CALENDAR) == false ||
+                permissions.get(Manifest.permission.WRITE_CALENDAR) == false) {
+                Toast.makeText(activity, R.string.calendar_permissions_required, Toast.LENGTH_LONG).show()
+                activity.finish()
+            }
+        }
+    }
+}

--- a/app/src/main/java/at/bitfire/icsdroid/PermissionUtils.kt
+++ b/app/src/main/java/at/bitfire/icsdroid/PermissionUtils.kt
@@ -1,3 +1,11 @@
+/*
+ * Copyright (c) Ricki Hirner (bitfire web engineering).
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the GNU Public License v3.0
+ * which accompanies this distribution, and is available at
+ * http://www.gnu.org/licenses/gpl.html
+ */
+
 package at.bitfire.icsdroid
 
 import android.Manifest

--- a/app/src/main/java/at/bitfire/icsdroid/PermissionUtils.kt
+++ b/app/src/main/java/at/bitfire/icsdroid/PermissionUtils.kt
@@ -6,14 +6,13 @@ package at.bitfire.icsdroid
 
 import android.Manifest
 import android.widget.Toast
-import androidx.activity.result.ActivityResultLauncher
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.appcompat.app.AppCompatActivity
 
 class PermissionUtils(val activity: AppCompatActivity) {
 
-    fun getCalendarPermissionRequestLauncher(): ActivityResultLauncher<Array<String>> {
-        return activity.registerForActivityResult(
+    fun registerCalendarPermissionRequestLauncher() =
+        activity.registerForActivityResult(
             ActivityResultContracts.RequestMultiplePermissions()
         ) { permissions ->
             if (permissions.get(Manifest.permission.READ_CALENDAR) == false ||
@@ -22,5 +21,5 @@ class PermissionUtils(val activity: AppCompatActivity) {
                 activity.finish()
             }
         }
-    }
+
 }

--- a/app/src/main/java/at/bitfire/icsdroid/ui/AddCalendarActivity.kt
+++ b/app/src/main/java/at/bitfire/icsdroid/ui/AddCalendarActivity.kt
@@ -16,8 +16,10 @@ import androidx.activity.result.contract.ActivityResultContracts
 import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.app.ActivityCompat
+import at.bitfire.icsdroid.PermissionUtils
 import at.bitfire.icsdroid.R
 import at.bitfire.icsdroid.db.LocalCalendar
+import java.security.AccessController.getContext
 
 class AddCalendarActivity: AppCompatActivity() {
 
@@ -34,19 +36,11 @@ class AddCalendarActivity: AppCompatActivity() {
 
         supportActionBar?.setDisplayHomeAsUpEnabled(true)
 
-        val requestPermissionLauncher = registerForActivityResult(
-            ActivityResultContracts.RequestMultiplePermissions()
-        ) { permissions ->
-            if (permissions.get(Manifest.permission.READ_CALENDAR) == false ||
-                permissions.get(Manifest.permission.WRITE_CALENDAR) == false) {
-                Toast.makeText(this, R.string.calendar_permissions_required, Toast.LENGTH_LONG).show()
-                finish()
-            }
-        }
-        
+        val calendarPermissionRequestLauncher = PermissionUtils(this).getCalendarPermissionRequestLauncher()
+
         if (ActivityCompat.checkSelfPermission(this, Manifest.permission.READ_CALENDAR) != PackageManager.PERMISSION_GRANTED ||
             ActivityCompat.checkSelfPermission(this, Manifest.permission.WRITE_CALENDAR) != PackageManager.PERMISSION_GRANTED)
-            requestPermissionLauncher.launch(arrayOf(Manifest.permission.READ_CALENDAR, Manifest.permission.WRITE_CALENDAR))
+            calendarPermissionRequestLauncher.launch(arrayOf(Manifest.permission.READ_CALENDAR, Manifest.permission.WRITE_CALENDAR))
 
         if (inState == null) {
             supportFragmentManager

--- a/app/src/main/java/at/bitfire/icsdroid/ui/AddCalendarActivity.kt
+++ b/app/src/main/java/at/bitfire/icsdroid/ui/AddCalendarActivity.kt
@@ -28,8 +28,7 @@ class AddCalendarActivity: AppCompatActivity() {
 
         supportActionBar?.setDisplayHomeAsUpEnabled(true)
 
-        val calendarPermissionRequestLauncher = PermissionUtils(this).getCalendarPermissionRequestLauncher()
-
+        val calendarPermissionRequestLauncher = PermissionUtils(this).registerCalendarPermissionRequestLauncher()
         if (ActivityCompat.checkSelfPermission(this, Manifest.permission.READ_CALENDAR) != PackageManager.PERMISSION_GRANTED ||
             ActivityCompat.checkSelfPermission(this, Manifest.permission.WRITE_CALENDAR) != PackageManager.PERMISSION_GRANTED)
             calendarPermissionRequestLauncher.launch(arrayOf(Manifest.permission.READ_CALENDAR, Manifest.permission.WRITE_CALENDAR))

--- a/app/src/main/java/at/bitfire/icsdroid/ui/AddCalendarActivity.kt
+++ b/app/src/main/java/at/bitfire/icsdroid/ui/AddCalendarActivity.kt
@@ -11,15 +11,11 @@ package at.bitfire.icsdroid.ui
 import android.Manifest
 import android.content.pm.PackageManager
 import android.os.Bundle
-import android.widget.Toast
-import androidx.activity.result.contract.ActivityResultContracts
 import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.app.ActivityCompat
 import at.bitfire.icsdroid.PermissionUtils
-import at.bitfire.icsdroid.R
 import at.bitfire.icsdroid.db.LocalCalendar
-import java.security.AccessController.getContext
 
 class AddCalendarActivity: AppCompatActivity() {
 

--- a/app/src/main/java/at/bitfire/icsdroid/ui/AddCalendarActivity.kt
+++ b/app/src/main/java/at/bitfire/icsdroid/ui/AddCalendarActivity.kt
@@ -12,6 +12,7 @@ import android.Manifest
 import android.content.pm.PackageManager
 import android.os.Bundle
 import android.widget.Toast
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.app.ActivityCompat
@@ -33,10 +34,19 @@ class AddCalendarActivity: AppCompatActivity() {
 
         supportActionBar?.setDisplayHomeAsUpEnabled(true)
 
+        val requestPermissionLauncher = registerForActivityResult(
+            ActivityResultContracts.RequestMultiplePermissions()
+        ) { permissions ->
+            if (permissions.get(Manifest.permission.READ_CALENDAR) == false ||
+                permissions.get(Manifest.permission.WRITE_CALENDAR) == false) {
+                Toast.makeText(this, R.string.calendar_permissions_required, Toast.LENGTH_LONG).show()
+                finish()
+            }
+        }
+        
         if (ActivityCompat.checkSelfPermission(this, Manifest.permission.READ_CALENDAR) != PackageManager.PERMISSION_GRANTED ||
             ActivityCompat.checkSelfPermission(this, Manifest.permission.WRITE_CALENDAR) != PackageManager.PERMISSION_GRANTED)
-            ActivityCompat.requestPermissions(this,
-                    arrayOf(Manifest.permission.READ_CALENDAR, Manifest.permission.WRITE_CALENDAR), 0)
+            requestPermissionLauncher.launch(arrayOf(Manifest.permission.READ_CALENDAR, Manifest.permission.WRITE_CALENDAR))
 
         if (inState == null) {
             supportFragmentManager
@@ -54,21 +64,6 @@ class AddCalendarActivity: AppCompatActivity() {
                 if (hasExtra(EXTRA_COLOR))
                     titleColorModel.color.value = getIntExtra(EXTRA_COLOR, LocalCalendar.DEFAULT_COLOR)
             }
-        }
-    }
-
-    override fun onRequestPermissionsResult(requestCode: Int, permissions: Array<out String>, grantResults: IntArray) {
-        super.onRequestPermissionsResult(requestCode, permissions, grantResults)
-
-        permissions.forEachIndexed { idx, perm ->
-            if (grantResults[idx] != PackageManager.PERMISSION_GRANTED)
-                when (perm) {
-                    Manifest.permission.READ_CALENDAR,
-                    Manifest.permission.WRITE_CALENDAR -> {
-                        Toast.makeText(this, R.string.calendar_permissions_required, Toast.LENGTH_LONG).show()
-                        finish()
-                    }
-                }
         }
     }
 

--- a/app/src/main/java/at/bitfire/icsdroid/ui/CalendarListActivity.kt
+++ b/app/src/main/java/at/bitfire/icsdroid/ui/CalendarListActivity.kt
@@ -24,8 +24,6 @@ import android.provider.CalendarContract
 import android.provider.Settings
 import android.util.Log
 import android.view.*
-import android.widget.Toast
-import androidx.activity.result.contract.ActivityResultContracts
 import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
 import androidx.appcompat.app.AppCompatDelegate

--- a/app/src/main/java/at/bitfire/icsdroid/ui/CalendarListActivity.kt
+++ b/app/src/main/java/at/bitfire/icsdroid/ui/CalendarListActivity.kt
@@ -71,19 +71,9 @@ class CalendarListActivity: AppCompatActivity(), SwipeRefreshLayout.OnRefreshLis
         binding.refresh.setOnRefreshListener(this)
         binding.refresh.setSize(SwipeRefreshLayout.LARGE)
 
-        val requestPermissionLauncher = registerForActivityResult(
-            ActivityResultContracts.RequestMultiplePermissions()
-        ) { permissions ->
-            if (permissions.get(Manifest.permission.READ_CALENDAR) == false ||
-                permissions.get(Manifest.permission.WRITE_CALENDAR) == false) {
-                Toast.makeText(this, R.string.calendar_permissions_required, Toast.LENGTH_LONG).show()
-                finish()
-            }
-        }
-
         model.askForPermissions.observe(this) { ask ->
             if (ask)
-                requestPermissionLauncher.launch(CalendarModel.PERMISSIONS)
+                PermissionUtils(this).getCalendarPermissionRequestLauncher().launch(CalendarModel.PERMISSIONS)
         }
 
         model.isRefreshing.observe(this) { isRefreshing ->

--- a/app/src/main/java/at/bitfire/icsdroid/ui/CalendarListActivity.kt
+++ b/app/src/main/java/at/bitfire/icsdroid/ui/CalendarListActivity.kt
@@ -65,8 +65,7 @@ class CalendarListActivity: AppCompatActivity(), SwipeRefreshLayout.OnRefreshLis
         binding.refresh.setOnRefreshListener(this)
         binding.refresh.setSize(SwipeRefreshLayout.LARGE)
 
-        val calendarPermissionsRequestLauncher = PermissionUtils(this).getCalendarPermissionRequestLauncher()
-
+        val calendarPermissionsRequestLauncher = PermissionUtils(this).registerCalendarPermissionRequestLauncher()
         model.askForPermissions.observe(this) { ask ->
             if (ask)
                 calendarPermissionsRequestLauncher.launch(CalendarModel.PERMISSIONS)

--- a/app/src/main/java/at/bitfire/icsdroid/ui/CalendarListActivity.kt
+++ b/app/src/main/java/at/bitfire/icsdroid/ui/CalendarListActivity.kt
@@ -69,9 +69,11 @@ class CalendarListActivity: AppCompatActivity(), SwipeRefreshLayout.OnRefreshLis
         binding.refresh.setOnRefreshListener(this)
         binding.refresh.setSize(SwipeRefreshLayout.LARGE)
 
+        val calendarPermissionsRequestLauncher = PermissionUtils(this).getCalendarPermissionRequestLauncher()
+
         model.askForPermissions.observe(this) { ask ->
             if (ask)
-                PermissionUtils(this).getCalendarPermissionRequestLauncher().launch(CalendarModel.PERMISSIONS)
+                calendarPermissionsRequestLauncher.launch(CalendarModel.PERMISSIONS)
         }
 
         model.isRefreshing.observe(this) { isRefreshing ->


### PR DESCRIPTION
Fix startup crash, by registering the permission launcher in onCreate (instead of callback) and before view is loaded.