### PR TITLE
Add support for COLOR property (closes icsx5#31)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -95,6 +95,7 @@ dependencies {
     // for tests
     androidTestImplementation 'androidx.test:runner:1.4.0'
     androidTestImplementation "androidx.test:rules:1.4.0"
+    androidTestImplementation "androidx.arch.core:core-testing:2.1.0"
     androidTestImplementation 'junit:junit:4.13.2'
     androidTestImplementation "com.squareup.okhttp3:mockwebserver:${versions.okhttp}"
 

--- a/app/src/androidTest/java/at/bitfire/icsdroid/CalendarFetcherTest.kt
+++ b/app/src/androidTest/java/at/bitfire/icsdroid/CalendarFetcherTest.kt
@@ -5,7 +5,6 @@
 package at.bitfire.icsdroid
 
 import android.content.ContentResolver
-import android.content.Context
 import android.net.Uri
 import androidx.test.platform.app.InstrumentationRegistry
 import at.bitfire.icsdroid.HttpUtils.toAndroidUri
@@ -15,7 +14,7 @@ import okhttp3.MediaType
 import okhttp3.mockwebserver.MockResponse
 import okhttp3.mockwebserver.MockWebServer
 import org.apache.commons.io.IOUtils
-import org.junit.After
+import org.junit.AfterClass
 import org.junit.Assert.assertArrayEquals
 import org.junit.Assert.assertEquals
 import org.junit.BeforeClass
@@ -29,21 +28,19 @@ class CalendarFetcherTest {
 
     companion object {
 
-        private lateinit var appContext: Context
-        private lateinit var testContext: Context
-        lateinit var server: MockWebServer
+        val appContext = InstrumentationRegistry.getInstrumentation().targetContext!!
+        val testContext = InstrumentationRegistry.getInstrumentation().context!!
+
+        val server = MockWebServer()
 
         @BeforeClass
         @JvmStatic
         fun setUp() {
-            appContext = InstrumentationRegistry.getInstrumentation().targetContext
-            testContext = InstrumentationRegistry.getInstrumentation().context
-
-            server = MockWebServer()
-            server.start(3000)
+            server.start()
         }
 
-        @After
+        @AfterClass
+        @JvmStatic
         fun tearDown() {
             server.shutdown()
         }

--- a/app/src/androidTest/java/at/bitfire/icsdroid/ui/AddCalendarValidationFragmentTest.kt
+++ b/app/src/androidTest/java/at/bitfire/icsdroid/ui/AddCalendarValidationFragmentTest.kt
@@ -1,0 +1,124 @@
+/***************************************************************************************************
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
+ **************************************************************************************************/
+
+package at.bitfire.icsdroid.ui
+
+import android.app.Application
+import androidx.arch.core.executor.testing.InstantTaskExecutorRule
+import androidx.lifecycle.Observer
+import androidx.test.platform.app.InstrumentationRegistry
+import at.bitfire.ical4android.Css3Color
+import at.bitfire.icsdroid.HttpUtils.toAndroidUri
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import org.junit.AfterClass
+import org.junit.Assert.*
+import org.junit.BeforeClass
+import org.junit.Rule
+import org.junit.Test
+
+class AddCalendarValidationFragmentTest {
+
+    companion object {
+
+        val app = InstrumentationRegistry.getInstrumentation().targetContext.applicationContext as Application
+
+        lateinit var server: MockWebServer
+
+        @BeforeClass
+        @JvmStatic
+        fun setUp() {
+            server = MockWebServer()
+            server.start()
+        }
+
+        @AfterClass
+        @JvmStatic
+        fun tearDown() {
+            server.shutdown()
+        }
+
+    }
+
+    @get:Rule
+    val instantTaskExecutor = InstantTaskExecutorRule()
+
+
+    @Test
+    fun testModelInitialize_CalendarProperties_None() {
+        val info = validate(
+            "BEGIN:VCALENDAR\n" +
+                    "VERSION:2.0\n" +
+                    "END:VCALENDAR\n"
+        )
+        assertNull(info.calendarName)
+        assertNull(info.calendarColor)
+    }
+
+    @Test
+    fun testModelInitialize_CalendarProperties_NameAndColor() {
+        val info = validate(
+            "BEGIN:VCALENDAR\n" +
+            "VERSION:2.0\n" +
+            "X-WR-CALNAME:Some Calendar\n" +
+            "COLOR:lightblue\n" +
+            "END:VCALENDAR\n"
+        )
+        assertEquals("Some Calendar", info.calendarName)
+        assertEquals(Css3Color.lightblue.argb, info.calendarColor)
+    }
+
+    @Test
+    fun testModelInitialize_CalendarProperties_NameAndLegacyColor() {
+        val info = validate(
+            "BEGIN:VCALENDAR\n" +
+                    "VERSION:2.0\n" +
+                    "X-WR-CALNAME:Some Calendar\n" +
+                    "X-APPLE-CALENDAR-COLOR:#123456\n" +
+                    "END:VCALENDAR\n"
+        )
+        assertEquals(0xFF123456.toInt(), info.calendarColor)
+    }
+
+    @Test
+    fun testModelInitialize_CalendarProperties_ColorAndLegacyColor() {
+        val info = validate(
+            "BEGIN:VCALENDAR\n" +
+                    "VERSION:2.0\n" +
+                    "X-APPLE-CALENDAR-COLOR:#123456\n" +
+                    "COLOR:lightblue\n" +
+                    "END:VCALENDAR\n"
+        )
+        assertEquals(Css3Color.lightblue.argb, info.calendarColor)
+    }
+
+    private fun validate(iCal: String): ResourceInfo {
+        val model = AddCalendarValidationFragment.ValidationModel(app)
+
+        server.enqueue(MockResponse().setBody(iCal))
+
+        val lock = Object()
+        val observer = Observer<ResourceInfo> {
+            synchronized(lock) {
+                lock.notify()
+            }
+        }
+        model.result.observeForever(observer)
+        try {
+            model.initialize(server.url("/").toAndroidUri(), null, null)
+
+            // wait for result
+            synchronized(lock) {
+                lock.wait(5000)
+            }
+        } finally {
+            model.result.removeObserver(observer)
+        }
+
+        val result = model.result.value
+        assertNotNull(result)
+        return result!!
+    }
+
+}

--- a/app/src/main/java/at/bitfire/icsdroid/ui/AddCalendarValidationFragment.kt
+++ b/app/src/main/java/at/bitfire/icsdroid/ui/AddCalendarValidationFragment.kt
@@ -10,6 +10,7 @@ import android.app.ProgressDialog
 import android.net.Uri
 import android.os.Bundle
 import android.util.Log
+import androidx.core.graphics.toColorInt
 import androidx.fragment.app.DialogFragment
 import androidx.fragment.app.activityViewModels
 import androidx.fragment.app.viewModels
@@ -45,7 +46,7 @@ class AddCalendarValidationFragment: DialogFragment() {
             if (exception == null) {
                 titleColorModel.url.value = info.uri.toString()
                 if (titleColorModel.color.value == null)
-                    titleColorModel.color.value = resources.getColor(R.color.lightblue)
+                    titleColorModel.color.value = info.calendarColor ?: resources.getColor(R.color.lightblue)
 
                 if (titleColorModel.title.value.isNullOrBlank())
                     titleColorModel.title.value = info.calendarName ?: info.uri.toString()
@@ -112,6 +113,7 @@ class AddCalendarValidationFragment: DialogFragment() {
                         val events = Event.eventsFromReader(reader, properties)
 
                         info.calendarName = properties[ICalendar.CALENDAR_NAME] ?: displayName
+                        info.calendarColor = properties[ICalendar.CALENDAR_COLOR]?.toColorInt()?: R.color.lightblue
                         info.eventsFound = events.size
                     }
 

--- a/app/src/main/java/at/bitfire/icsdroid/ui/AddCalendarValidationFragment.kt
+++ b/app/src/main/java/at/bitfire/icsdroid/ui/AddCalendarValidationFragment.kt
@@ -16,6 +16,7 @@ import androidx.fragment.app.activityViewModels
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.MutableLiveData
+import at.bitfire.ical4android.Css3Color
 import at.bitfire.ical4android.Event
 import at.bitfire.ical4android.ICalendar
 import at.bitfire.icsdroid.CalendarFetcher
@@ -24,9 +25,13 @@ import at.bitfire.icsdroid.HttpClient
 import at.bitfire.icsdroid.HttpUtils.toURI
 import at.bitfire.icsdroid.HttpUtils.toUri
 import at.bitfire.icsdroid.R
+import net.fortuna.ical4j.model.property.Color
 import okhttp3.MediaType
+import okhttp3.internal.wait
 import java.io.InputStream
 import java.io.InputStreamReader
+import java.util.concurrent.Future
+import java.util.concurrent.RunnableFuture
 
 class AddCalendarValidationFragment: DialogFragment() {
 
@@ -45,6 +50,7 @@ class AddCalendarValidationFragment: DialogFragment() {
             val exception = info.exception
             if (exception == null) {
                 titleColorModel.url.value = info.uri.toString()
+
                 if (titleColorModel.color.value == null)
                     titleColorModel.color.value = info.calendarColor ?: resources.getColor(R.color.lightblue)
 
@@ -113,7 +119,18 @@ class AddCalendarValidationFragment: DialogFragment() {
                         val events = Event.eventsFromReader(reader, properties)
 
                         info.calendarName = properties[ICalendar.CALENDAR_NAME] ?: displayName
-                        info.calendarColor = properties[ICalendar.CALENDAR_COLOR]?.toColorInt()?: R.color.lightblue
+                        info.calendarColor =
+                            // try COLOR first
+                            properties[Color.PROPERTY_NAME]?.let { colorName ->
+                                Css3Color.fromString(colorName)?.argb
+                            } ?:
+                            // try X-APPLE-CALENDAR-COLOR second
+                            try {
+                                properties[ICalendar.CALENDAR_COLOR]?.toColorInt()
+                            } catch (e: IllegalArgumentException) {
+                                Log.w(Constants.TAG, "Couldn't parse calendar COLOR", e)
+                                null
+                            }
                         info.eventsFound = events.size
                     }
 

--- a/app/src/main/java/at/bitfire/icsdroid/ui/ResourceInfo.kt
+++ b/app/src/main/java/at/bitfire/icsdroid/ui/ResourceInfo.kt
@@ -13,6 +13,7 @@ data class ResourceInfo(
     var exception: Exception? = null,
 
     var calendarName: String? = null,
+    var calendarColor: Int? = null,
     var eventsFound: Int = 0
 
 )


### PR DESCRIPTION
Not finished yet. Still needs fallback support for `X-APPLE-COLOR`.
Also tests are failing because changes in ical4android are not included.