### PR TITLE
Allow use of user-installed CAs

### DIFF
--- a/app/src/main/res/xml/network_security.xml
+++ b/app/src/main/res/xml/network_security.xml
@@ -1,4 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <network-security-config xmlns:tools="http://schemas.android.com/tools">
-    <base-config cleartextTrafficPermitted="true" tools:ignore="InsecureBaseConfiguration" />
+    <base-config cleartextTrafficPermitted="true" tools:ignore="InsecureBaseConfiguration">
+        <trust-anchors>
+            <certificates src="system"/>
+            <certificates src="user" tools:ignore="AcceptsUserCertificates" />
+        </trust-anchors>
+    </base-config>
 </network-security-config>


### PR DESCRIPTION
Fixes #43

As per https://developer.android.com/training/articles/security-config
Previous behaviour: only validated certificates in the system certificate
                    authority store
New behaviour: validates against both system CAs and user-installed CAs