### PR TITLE
Subscriptions in database: UI

### DIFF
--- a/app/src/main/java/at/bitfire/icsdroid/PermissionUtils.kt
+++ b/app/src/main/java/at/bitfire/icsdroid/PermissionUtils.kt
@@ -42,7 +42,8 @@ object PermissionUtils {
     fun haveNotificationPermission(context: Context) =
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU)
             ContextCompat.checkSelfPermission(context, Manifest.permission.POST_NOTIFICATIONS) == PackageManager.PERMISSION_GRANTED
-        else true
+        else
+            true
 
     /**
      * Registers for the result of the request of some permissions.

--- a/app/src/main/java/at/bitfire/icsdroid/PermissionUtils.kt
+++ b/app/src/main/java/at/bitfire/icsdroid/PermissionUtils.kt
@@ -7,6 +7,7 @@ package at.bitfire.icsdroid
 import android.Manifest
 import android.content.Context
 import android.content.pm.PackageManager
+import android.os.Build
 import android.util.Log
 import android.widget.Toast
 import androidx.activity.result.contract.ActivityResultContracts
@@ -30,6 +31,18 @@ object PermissionUtils {
     fun haveCalendarPermissions(context: Context) = CALENDAR_PERMISSIONS.all { permission ->
         ContextCompat.checkSelfPermission(context, permission) == PackageManager.PERMISSION_GRANTED
     }
+
+    /**
+     * Checks whether the calling app has permission to request notifications. If the device's SDK
+     * level is lower than Tiramisu, always returns `true`.
+     *
+     * @param context  context to check permissions within
+     * @return *true* if notification permissions are granted; *false* otherwise
+     */
+    fun haveNotificationPermission(context: Context) =
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU)
+            ContextCompat.checkSelfPermission(context, Manifest.permission.POST_NOTIFICATIONS) == PackageManager.PERMISSION_GRANTED
+        else true
 
     /**
      * Registers for the result of the request of some permissions.
@@ -81,5 +94,26 @@ object PermissionUtils {
             R.string.calendar_permissions_required,
             onGranted
         )
+
+    /**
+     * Registers a notification permission request launcher.
+     *
+     * @param activity   activity to register permission request launcher
+     * @param onGranted  called when calendar permissions have been granted
+     *
+     * @return Call the returning function to launch the request
+     */
+    fun registerNotificationPermissionRequest(activity: AppCompatActivity, onGranted: () -> Unit = {}) =
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU)
+            registerPermissionRequest(
+                activity,
+                arrayOf(Manifest.permission.POST_NOTIFICATIONS),
+                R.string.notification_permissions_required,
+                onGranted
+            )
+        else {
+            // If SDK level is not greater or equal than Tiramisu, do nothing
+            {}
+        }
 
 }

--- a/app/src/main/java/at/bitfire/icsdroid/ProcessEventsTask.kt
+++ b/app/src/main/java/at/bitfire/icsdroid/ProcessEventsTask.kt
@@ -5,11 +5,9 @@
 package at.bitfire.icsdroid
 
 import android.app.PendingIntent
-import android.content.ContentUris
 import android.content.Context
 import android.content.Intent
 import android.net.Uri
-import android.provider.CalendarContract
 import android.util.Log
 import androidx.core.app.NotificationCompat
 import at.bitfire.ical4android.Event
@@ -170,10 +168,9 @@ class ProcessEventsTask(
             val message = ex.localizedMessage ?: ex.message ?: ex.toString()
 
             val errorIntent = Intent(context, EditCalendarActivity::class.java)
-            errorIntent.data =
-                ContentUris.withAppendedId(CalendarContract.Calendars.CONTENT_URI, subscription.id)
-            errorIntent.putExtra(EditCalendarActivity.ERROR_MESSAGE, message)
-            errorIntent.putExtra(EditCalendarActivity.THROWABLE, ex)
+            errorIntent.putExtra(EditCalendarActivity.EXTRA_SUBSCRIPTION_ID, subscription.id)
+            errorIntent.putExtra(EditCalendarActivity.EXTRA_ERROR_MESSAGE, message)
+            errorIntent.putExtra(EditCalendarActivity.EXTRA_THROWABLE, ex)
 
             val notification = NotificationCompat.Builder(context, NotificationUtils.CHANNEL_SYNC)
                 .setSmallIcon(R.drawable.ic_sync_problem_white)

--- a/app/src/main/java/at/bitfire/icsdroid/SyncAdapter.kt
+++ b/app/src/main/java/at/bitfire/icsdroid/SyncAdapter.kt
@@ -10,6 +10,7 @@ import android.content.*
 import android.os.Bundle
 import androidx.core.app.NotificationCompat
 import androidx.work.WorkManager
+import at.bitfire.icsdroid.ui.AddCalendarActivity
 import at.bitfire.icsdroid.ui.CalendarListActivity
 import at.bitfire.icsdroid.ui.NotificationUtils
 
@@ -30,7 +31,9 @@ class SyncAdapter(
 
     override fun onSecurityException(account: Account?, extras: Bundle?, authority: String?, syncResult: SyncResult?) {
         val nm = NotificationUtils.createChannels(context)
-        val askPermissionsIntent = Intent(context, CalendarListActivity::class.java)
+        val askPermissionsIntent = Intent(context, CalendarListActivity::class.java).apply {
+            putExtra(AddCalendarActivity.EXTRA_PERMISSION, true)
+        }
         val notification = NotificationCompat.Builder(context, NotificationUtils.CHANNEL_SYNC)
                 .setSmallIcon(R.drawable.ic_sync_problem_white)
                 .setContentTitle(context.getString(R.string.sync_permission_required))

--- a/app/src/main/java/at/bitfire/icsdroid/SyncAdapter.kt
+++ b/app/src/main/java/at/bitfire/icsdroid/SyncAdapter.kt
@@ -5,13 +5,9 @@
 package at.bitfire.icsdroid
 
 import android.accounts.Account
-import android.app.PendingIntent
 import android.content.*
 import android.os.Bundle
-import androidx.core.app.NotificationCompat
 import androidx.work.WorkManager
-import at.bitfire.icsdroid.ui.AddCalendarActivity
-import at.bitfire.icsdroid.ui.CalendarListActivity
 import at.bitfire.icsdroid.ui.NotificationUtils
 
 class SyncAdapter(
@@ -30,20 +26,7 @@ class SyncAdapter(
     }
 
     override fun onSecurityException(account: Account?, extras: Bundle?, authority: String?, syncResult: SyncResult?) {
-        val nm = NotificationUtils.createChannels(context)
-        val askPermissionsIntent = Intent(context, CalendarListActivity::class.java).apply {
-            putExtra(CalendarListActivity.EXTRA_PERMISSION, true)
-        }
-        val notification = NotificationCompat.Builder(context, NotificationUtils.CHANNEL_SYNC)
-                .setSmallIcon(R.drawable.ic_sync_problem_white)
-                .setContentTitle(context.getString(R.string.sync_permission_required))
-                .setContentText(context.getString(R.string.sync_permission_required_sync_calendar))
-                .setCategory(NotificationCompat.CATEGORY_ERROR)
-                .setContentIntent(PendingIntent.getActivity(context, 0, askPermissionsIntent, PendingIntent.FLAG_UPDATE_CURRENT + NotificationUtils.flagImmutableCompat))
-                .setAutoCancel(true)
-                .setLocalOnly(true)
-                .build()
-        nm.notify(NotificationUtils.NOTIFY_PERMISSION, notification)
+        NotificationUtils.showCalendarPermissionNotification(context)
     }
 
 }

--- a/app/src/main/java/at/bitfire/icsdroid/SyncAdapter.kt
+++ b/app/src/main/java/at/bitfire/icsdroid/SyncAdapter.kt
@@ -32,7 +32,7 @@ class SyncAdapter(
     override fun onSecurityException(account: Account?, extras: Bundle?, authority: String?, syncResult: SyncResult?) {
         val nm = NotificationUtils.createChannels(context)
         val askPermissionsIntent = Intent(context, CalendarListActivity::class.java).apply {
-            putExtra(AddCalendarActivity.EXTRA_PERMISSION, true)
+            putExtra(CalendarListActivity.EXTRA_PERMISSION, true)
         }
         val notification = NotificationCompat.Builder(context, NotificationUtils.CHANNEL_SYNC)
                 .setSmallIcon(R.drawable.ic_sync_problem_white)

--- a/app/src/main/java/at/bitfire/icsdroid/SyncAdapter.kt
+++ b/app/src/main/java/at/bitfire/icsdroid/SyncAdapter.kt
@@ -11,7 +11,7 @@ import androidx.work.WorkManager
 import at.bitfire.icsdroid.ui.NotificationUtils
 
 class SyncAdapter(
-        context: Context
+    context: Context
 ): AbstractThreadedSyncAdapter(context, false) {
 
     override fun onPerformSync(account: Account, extras: Bundle, authority: String, provider: ContentProviderClient, syncResult: SyncResult) {
@@ -25,6 +25,9 @@ class SyncAdapter(
         wm.cancelUniqueWork(SyncWorker.NAME)
     }
 
+    /**
+     * Called by the sync framework when we don't have calendar permissions.
+     */
     override fun onSecurityException(account: Account?, extras: Bundle?, authority: String?, syncResult: SyncResult?) {
         NotificationUtils.showCalendarPermissionNotification(context)
     }

--- a/app/src/main/java/at/bitfire/icsdroid/SyncWorker.kt
+++ b/app/src/main/java/at/bitfire/icsdroid/SyncWorker.kt
@@ -84,9 +84,8 @@ class SyncWorker(
         forceReSync = inputData.getBoolean(FORCE_RESYNC, false)
         Log.i(TAG, "Synchronizing (forceReSync=$forceReSync)")
 
+        provider = LocalCalendar.getCalendarProvider(applicationContext)
         try {
-            provider = LocalCalendar.getCalendarProvider(applicationContext)
-
             // migrate old calendar-based subscriptions to database
             migrateLegacyCalendars()
 
@@ -109,7 +108,7 @@ class SyncWorker(
             Log.e(TAG, "Thread interrupted", e)
             return Result.retry()
         } finally {
-            if (this::provider.isInitialized) provider.closeCompat()
+            provider.closeCompat()
         }
 
         return Result.success()

--- a/app/src/main/java/at/bitfire/icsdroid/db/dao/CredentialsDao.kt
+++ b/app/src/main/java/at/bitfire/icsdroid/db/dao/CredentialsDao.kt
@@ -1,38 +1,22 @@
 package at.bitfire.icsdroid.db.dao
 
-import android.database.SQLException
-import androidx.room.Dao
-import androidx.room.Insert
-import androidx.room.Query
-import androidx.room.Update
+import androidx.room.*
 import at.bitfire.icsdroid.db.entity.Credential
-import at.bitfire.icsdroid.db.entity.Subscription
 
 @Dao
 interface CredentialsDao {
-    /**
-     * Gets all the credentials stored for the given subscription.
-     * @param subscriptionId The id of the subscription to get the credentials for.
-     * @return The [Credential] stored for the given [subscriptionId] or null if none.
-     * @throws SQLException If there's an error while fetching the credential.
-     */
+
     @Query("SELECT * FROM credentials WHERE subscriptionId=:subscriptionId")
     fun getBySubscriptionId(subscriptionId: Long): Credential?
 
-    /**
-     * Inserts a new credential into the table.
-     */
     @Insert
     fun create(credential: Credential)
 
-    /**
-     * Removes the credentials stored for the given subscription from the database.
-     * @param subscriptionId The id ([Subscription.id]) of the subscription that matches the stored
-     * credentials to be deleted.
-     * @throws SQLException If there's an error while making the deletion.
-     */
+    @Upsert
+    fun upsert(credential: Credential)
+
     @Query("DELETE FROM credentials WHERE subscriptionId=:subscriptionId")
-    fun remove(subscriptionId: Long)
+    fun removeBySubscriptionId(subscriptionId: Long)
 
     /** Updates a given calendar in the table */
     @Update

--- a/app/src/main/java/at/bitfire/icsdroid/db/dao/CredentialsDao.kt
+++ b/app/src/main/java/at/bitfire/icsdroid/db/dao/CredentialsDao.kt
@@ -18,7 +18,6 @@ interface CredentialsDao {
     @Query("DELETE FROM credentials WHERE subscriptionId=:subscriptionId")
     fun removeBySubscriptionId(subscriptionId: Long)
 
-    /** Updates a given calendar in the table */
     @Update
     fun update(credential: Credential)
 

--- a/app/src/main/java/at/bitfire/icsdroid/db/dao/CredentialsDao.kt
+++ b/app/src/main/java/at/bitfire/icsdroid/db/dao/CredentialsDao.kt
@@ -4,6 +4,7 @@ import android.database.SQLException
 import androidx.room.Dao
 import androidx.room.Insert
 import androidx.room.Query
+import androidx.room.Update
 import at.bitfire.icsdroid.db.entity.Credential
 import at.bitfire.icsdroid.db.entity.Subscription
 
@@ -32,5 +33,9 @@ interface CredentialsDao {
      */
     @Query("DELETE FROM credentials WHERE subscriptionId=:subscriptionId")
     fun remove(subscriptionId: Long)
+
+    /** Updates a given calendar in the table */
+    @Update
+    fun update(credential: Credential)
 
 }

--- a/app/src/main/java/at/bitfire/icsdroid/db/dao/SubscriptionsDao.kt
+++ b/app/src/main/java/at/bitfire/icsdroid/db/dao/SubscriptionsDao.kt
@@ -3,6 +3,7 @@ package at.bitfire.icsdroid.db.dao
 import android.net.Uri
 import androidx.lifecycle.LiveData
 import androidx.room.*
+import at.bitfire.icsdroid.db.entity.Credential
 import at.bitfire.icsdroid.db.entity.Subscription
 
 @Dao
@@ -23,6 +24,9 @@ interface SubscriptionsDao {
     @Query("SELECT * FROM subscriptions WHERE id=:id")
     fun getById(id: Long): Subscription?
 
+    @Query("SELECT * FROM subscriptions WHERE id=:id")
+    fun getWithCredentialsByIdLive(id: Long): LiveData<SubscriptionWithCredential>
+
     @Query("SELECT errorMessage FROM subscriptions WHERE id=:id")
     fun getErrorMessageLive(id: Long): LiveData<String?>
 
@@ -40,5 +44,15 @@ interface SubscriptionsDao {
 
     @Query("UPDATE subscriptions SET url=:url WHERE id=:id")
     fun updateUrl(id: Long, url: Uri)
+
+
+    data class SubscriptionWithCredential(
+        @Embedded val subscription: Subscription,
+        @Relation(
+            parentColumn = "id",
+            entityColumn = "subscriptionId"
+        )
+        val credential: Credential?
+    )
 
 }

--- a/app/src/main/java/at/bitfire/icsdroid/db/dao/SubscriptionsDao.kt
+++ b/app/src/main/java/at/bitfire/icsdroid/db/dao/SubscriptionsDao.kt
@@ -9,7 +9,7 @@ import at.bitfire.icsdroid.db.entity.Subscription
 interface SubscriptionsDao {
 
     @Insert
-    fun add(vararg subscriptions: Subscription)
+    fun add(vararg subscriptions: Subscription): List<Long>
 
     @Delete
     fun delete(vararg subscriptions: Subscription)

--- a/app/src/main/java/at/bitfire/icsdroid/db/entity/Credential.kt
+++ b/app/src/main/java/at/bitfire/icsdroid/db/entity/Credential.kt
@@ -11,7 +11,7 @@ import androidx.room.PrimaryKey
     tableName = "credentials",
     foreignKeys = [
         ForeignKey(entity = Subscription::class, parentColumns = ["id"], childColumns = ["subscriptionId"], onDelete = ForeignKey.CASCADE),
-    ],
+    ]
 )
 data class Credential(
     @PrimaryKey val subscriptionId: Long,

--- a/app/src/main/java/at/bitfire/icsdroid/ui/AddCalendarActivity.kt
+++ b/app/src/main/java/at/bitfire/icsdroid/ui/AddCalendarActivity.kt
@@ -15,8 +15,6 @@ class AddCalendarActivity: AppCompatActivity() {
     companion object {
         const val EXTRA_TITLE = "title"
         const val EXTRA_COLOR = "color"
-
-        const val EXTRA_PERMISSION = "permission"
     }
 
     private val titleColorModel by viewModels<TitleColorFragment.TitleColorModel>()
@@ -26,12 +24,6 @@ class AddCalendarActivity: AppCompatActivity() {
         super.onCreate(inState)
 
         supportActionBar?.setDisplayHomeAsUpEnabled(true)
-
-        val requestPermissions = intent.getBooleanExtra(EXTRA_PERMISSION, false)
-        if (requestPermissions && !PermissionUtils.haveCalendarPermissions(this)) {
-            PermissionUtils
-                .registerCalendarPermissionRequest(this)()
-        }
 
         if (inState == null) {
             supportFragmentManager

--- a/app/src/main/java/at/bitfire/icsdroid/ui/AddCalendarActivity.kt
+++ b/app/src/main/java/at/bitfire/icsdroid/ui/AddCalendarActivity.kt
@@ -15,6 +15,8 @@ class AddCalendarActivity: AppCompatActivity() {
     companion object {
         const val EXTRA_TITLE = "title"
         const val EXTRA_COLOR = "color"
+
+        const val EXTRA_PERMISSION = "permission"
     }
 
     private val titleColorModel by viewModels<TitleColorFragment.TitleColorModel>()
@@ -25,7 +27,8 @@ class AddCalendarActivity: AppCompatActivity() {
 
         supportActionBar?.setDisplayHomeAsUpEnabled(true)
 
-        if (!PermissionUtils.haveCalendarPermissions(this)) {
+        val requestPermissions = intent.getBooleanExtra(EXTRA_PERMISSION, false)
+        if (requestPermissions && !PermissionUtils.haveCalendarPermissions(this)) {
             PermissionUtils
                 .registerCalendarPermissionRequest(this)()
         }

--- a/app/src/main/java/at/bitfire/icsdroid/ui/AddCalendarDetailsFragment.kt
+++ b/app/src/main/java/at/bitfire/icsdroid/ui/AddCalendarDetailsFragment.kt
@@ -13,6 +13,7 @@ import android.widget.Toast
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.activityViewModels
 import androidx.lifecycle.AndroidViewModel
+import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.Observer
 import androidx.lifecycle.viewModelScope
 import at.bitfire.icsdroid.Constants
@@ -28,7 +29,7 @@ class AddCalendarDetailsFragment: Fragment() {
 
     private val titleColorModel by activityViewModels<TitleColorFragment.TitleColorModel>()
     private val credentialsModel by activityViewModels<CredentialsFragment.CredentialsModel>()
-    private val creationModel by activityViewModels<CreateSubscriptionViewModel>()
+    private val model by activityViewModels<SubscriptionModel>()
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -49,6 +50,23 @@ class AddCalendarDetailsFragment: Fragment() {
         val v = inflater.inflate(R.layout.add_calendar_details, container, false)
         setHasOptionsMenu(true)
 
+        // Handle status changes
+        model.success.observe(viewLifecycleOwner) { success ->
+            if (success) {
+                // success, show notification and close activity
+                Toast.makeText(
+                    requireActivity(),
+                    requireActivity().getString(R.string.add_calendar_created),
+                    Toast.LENGTH_LONG
+                ).show()
+
+                requireActivity().finish()
+            }
+        }
+        model.errorMessage.observe(viewLifecycleOwner) { message ->
+            Toast.makeText(requireActivity(), message, Toast.LENGTH_LONG).show()
+        }
+
         return v
     }
 
@@ -62,65 +80,65 @@ class AddCalendarDetailsFragment: Fragment() {
     }
 
     override fun onOptionsItemSelected(item: MenuItem) =
-            if (item.itemId == R.id.create_calendar) {
-                creationModel.createSubscription(titleColorModel, credentialsModel)
-                    .invokeOnCompletion {
-                        // Finish the activity to go back to the subscriptions list
-                        activity?.finish()
-                    }
-                true
-            } else
-                false
+        if (item.itemId == R.id.create_calendar) {
+            model.create(titleColorModel, credentialsModel)
+            true
+        } else
+            false
 
-    class CreateSubscriptionViewModel(application: Application) : AndroidViewModel(application) {
+
+    class SubscriptionModel(application: Application) : AndroidViewModel(application) {
+
         private val database = AppDatabase.getInstance(getApplication())
         private val subscriptionsDao = database.subscriptionsDao()
         private val credentialsDao = database.credentialsDao()
 
+        val success = MutableLiveData(false)
+        val errorMessage = MutableLiveData<String>()
+
         /**
          * Creates a new subscription taking the data from the given models.
          */
-        fun createSubscription(
+        fun create(
             titleColorModel: TitleColorFragment.TitleColorModel,
             credentialsModel: CredentialsFragment.CredentialsModel,
-        ) = viewModelScope.launch {
-            val application = getApplication<Application>()
-
-            try {
-                val subscription = Subscription(
-                    displayName = titleColorModel.title.value!!,
-                    url = Uri.parse(titleColorModel.url.value),
-                    color = titleColorModel.color.value,
-                    ignoreEmbeddedAlerts = titleColorModel.ignoreAlerts.value ?: false,
-                    defaultAlarmMinutes = titleColorModel.defaultAlarmMinutes.value
-                )
-
-                /** A list of all the ids of the inserted rows, should only contain one value */
-                val ids = withContext(Dispatchers.IO) { subscriptionsDao.add(subscription) }
-
-                /** The id of the newly inserted subscription */
-                val id = ids.first()
-
-                // Create the credential in the IO thread
-                if (credentialsModel.requiresAuth.value == true) withContext(Dispatchers.IO) {
-                    // If the subscription requires credentials, create them
-                    val credential = Credential(
-                        subscriptionId = id,
-                        username = credentialsModel.username.value!!,
-                        password = credentialsModel.password.value!!
+        ) {
+            viewModelScope.launch(Dispatchers.IO) {
+                try {
+                    val subscription = Subscription(
+                        displayName = titleColorModel.title.value!!,
+                        url = Uri.parse(titleColorModel.url.value),
+                        color = titleColorModel.color.value,
+                        ignoreEmbeddedAlerts = titleColorModel.ignoreAlerts.value ?: false,
+                        defaultAlarmMinutes = titleColorModel.defaultAlarmMinutes.value
                     )
-                    credentialsDao.create(credential)
-                }
 
-                // Show a toast informing that the calendar has been created
-                Toast.makeText(
-                    application,
-                    application.getString(R.string.add_calendar_created),
-                    Toast.LENGTH_LONG
-                ).show()
-            } catch (e: Exception) {
-                Log.e(Constants.TAG, "Couldn't create calendar", e)
-                Toast.makeText(application, e.localizedMessage, Toast.LENGTH_LONG).show()
+                    /** A list of all the ids of the inserted rows, should only contain one value */
+                    val ids = withContext(Dispatchers.IO) { subscriptionsDao.add(subscription) }
+
+                    /** The id of the newly inserted subscription */
+                    val id = ids.first()
+
+                    // Create the credential in the IO thread
+                    if (credentialsModel.requiresAuth.value == true) {
+                        // If the subscription requires credentials, create them
+                        val username = credentialsModel.username.value
+                        val password = credentialsModel.password.value
+                        if (username != null && password != null) {
+                            val credential = Credential(
+                                subscriptionId = id,
+                                username = username,
+                                password = password
+                            )
+                            credentialsDao.create(credential)
+                        }
+                    }
+
+                    success.postValue(true)
+                } catch (e: Exception) {
+                    Log.e(Constants.TAG, "Couldn't create calendar", e)
+                    errorMessage.postValue(e.localizedMessage)
+                }
             }
         }
     }

--- a/app/src/main/java/at/bitfire/icsdroid/ui/CalendarListActivity.kt
+++ b/app/src/main/java/at/bitfire/icsdroid/ui/CalendarListActivity.kt
@@ -47,7 +47,10 @@ class CalendarListActivity: AppCompatActivity(), SwipeRefreshLayout.OnRefreshLis
     private lateinit var binding: CalendarListActivityBinding
 
     /** Stores the calendar permission request for asking for calendar permissions during runtime */
-    private lateinit var requestPermissions: () -> Unit
+    private lateinit var requestCalendarPermissions: () -> Unit
+
+    /** Stores the post notification permission request for asking for permissions during runtime */
+    private lateinit var requestNotificationPermission: () -> Unit
 
     private var snackBar: Snackbar? = null
 
@@ -56,9 +59,12 @@ class CalendarListActivity: AppCompatActivity(), SwipeRefreshLayout.OnRefreshLis
         setTitle(R.string.title_activity_calendar_list)
 
         // Register the calendar permission request
-        requestPermissions = PermissionUtils.registerCalendarPermissionRequest(this) {
+        requestCalendarPermissions = PermissionUtils.registerCalendarPermissionRequest(this) {
             SyncWorker.run(this)
         }
+
+        // Register the notifications permission request
+        requestNotificationPermission = PermissionUtils.registerNotificationPermissionRequest(this)
 
         binding = DataBindingUtil.setContentView(this, R.layout.calendar_list_activity)
         binding.lifecycleOwner = this
@@ -90,7 +96,7 @@ class CalendarListActivity: AppCompatActivity(), SwipeRefreshLayout.OnRefreshLis
         // If EXTRA_PERMISSION is true, request the calendar permissions
         val requestPermissions = intent.getBooleanExtra(EXTRA_PERMISSION, false)
         if (requestPermissions && !PermissionUtils.haveCalendarPermissions(this)) {
-            requestPermissions()
+            requestCalendarPermissions()
         }
 
         model.subscriptions.observe(this) { subscriptions ->
@@ -139,10 +145,17 @@ class CalendarListActivity: AppCompatActivity(), SwipeRefreshLayout.OnRefreshLis
         snackBar = null
 
         when {
+            // notification permissions are granted
+            !PermissionUtils.haveNotificationPermission(this) -> {
+                snackBar = Snackbar.make(binding.coordinator, R.string.notification_permissions_required, Snackbar.LENGTH_INDEFINITE)
+                    .setAction(R.string.permissions_grant) { requestNotificationPermission() }
+                    .also { it.show() }
+            }
+
             // calendar permissions are granted
             !PermissionUtils.haveCalendarPermissions(this) -> {
                 snackBar = Snackbar.make(binding.coordinator, R.string.calendar_permissions_required, Snackbar.LENGTH_INDEFINITE)
-                    .setAction(R.string.permissions_grant) { requestPermissions() }
+                    .setAction(R.string.permissions_grant) { requestCalendarPermissions() }
                     .also { it.show() }
             }
 

--- a/app/src/main/java/at/bitfire/icsdroid/ui/CalendarListActivity.kt
+++ b/app/src/main/java/at/bitfire/icsdroid/ui/CalendarListActivity.kt
@@ -39,6 +39,10 @@ import java.util.*
 
 class CalendarListActivity: AppCompatActivity(), SwipeRefreshLayout.OnRefreshListener {
 
+    companion object {
+        const val EXTRA_PERMISSION = "permission"
+    }
+
     private val model by viewModels<SubscriptionsModel>()
     private lateinit var binding: CalendarListActivityBinding
 
@@ -73,6 +77,15 @@ class CalendarListActivity: AppCompatActivity(), SwipeRefreshLayout.OnRefreshLis
 
         binding.fab.setOnClickListener {
             onAddCalendar()
+        }
+
+        // If EXTRA_PERMISSION is true, request the calendar permissions
+        val requestPermissions = intent.getBooleanExtra(EXTRA_PERMISSION, false)
+        if (requestPermissions && !PermissionUtils.haveCalendarPermissions(this)) {
+            PermissionUtils.registerCalendarPermissionRequest(this) {
+                // If permission was granted, run synchronization
+                SyncWorker.run(this)
+            }()
         }
 
         model.subscriptions.observe(this) { subscriptions ->

--- a/app/src/main/java/at/bitfire/icsdroid/ui/CalendarListActivity.kt
+++ b/app/src/main/java/at/bitfire/icsdroid/ui/CalendarListActivity.kt
@@ -46,11 +46,19 @@ class CalendarListActivity: AppCompatActivity(), SwipeRefreshLayout.OnRefreshLis
     private val model by viewModels<SubscriptionsModel>()
     private lateinit var binding: CalendarListActivityBinding
 
+    /** Stores the calendar permission request for asking for calendar permissions during runtime */
+    private lateinit var requestPermissions: () -> Unit
+
     private var snackBar: Snackbar? = null
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setTitle(R.string.title_activity_calendar_list)
+
+        // Register the calendar permission request
+        requestPermissions = PermissionUtils.registerCalendarPermissionRequest(this) {
+            SyncWorker.run(this)
+        }
 
         binding = DataBindingUtil.setContentView(this, R.layout.calendar_list_activity)
         binding.lifecycleOwner = this
@@ -82,10 +90,7 @@ class CalendarListActivity: AppCompatActivity(), SwipeRefreshLayout.OnRefreshLis
         // If EXTRA_PERMISSION is true, request the calendar permissions
         val requestPermissions = intent.getBooleanExtra(EXTRA_PERMISSION, false)
         if (requestPermissions && !PermissionUtils.haveCalendarPermissions(this)) {
-            PermissionUtils.registerCalendarPermissionRequest(this) {
-                // If permission was granted, run synchronization
-                SyncWorker.run(this)
-            }()
+            requestPermissions()
         }
 
         model.subscriptions.observe(this) { subscriptions ->
@@ -137,11 +142,7 @@ class CalendarListActivity: AppCompatActivity(), SwipeRefreshLayout.OnRefreshLis
             // calendar permissions are granted
             !PermissionUtils.haveCalendarPermissions(this) -> {
                 snackBar = Snackbar.make(binding.coordinator, R.string.calendar_permissions_required, Snackbar.LENGTH_INDEFINITE)
-                    .setAction(R.string.permissions_grant) {
-                        PermissionUtils.registerCalendarPermissionRequest(this) {
-                            SyncWorker.run(this)
-                        }
-                    }
+                    .setAction(R.string.permissions_grant) { requestPermissions() }
                     .also { it.show() }
             }
 

--- a/app/src/main/java/at/bitfire/icsdroid/ui/CalendarListActivity.kt
+++ b/app/src/main/java/at/bitfire/icsdroid/ui/CalendarListActivity.kt
@@ -134,6 +134,17 @@ class CalendarListActivity: AppCompatActivity(), SwipeRefreshLayout.OnRefreshLis
         snackBar = null
 
         when {
+            // calendar permissions are granted
+            !PermissionUtils.haveCalendarPermissions(this) -> {
+                snackBar = Snackbar.make(binding.coordinator, R.string.calendar_permissions_required, Snackbar.LENGTH_INDEFINITE)
+                    .setAction(R.string.permissions_grant) {
+                        PermissionUtils.registerCalendarPermissionRequest(this) {
+                            SyncWorker.run(this)
+                        }
+                    }
+                    .also { it.show() }
+            }
+
             // periodic sync not enabled
             AppAccount.syncInterval(this) == AppAccount.SYNC_INTERVAL_MANUALLY -> {
                 snackBar = Snackbar.make(binding.coordinator, R.string.calendar_list_sync_interval_manually, Snackbar.LENGTH_INDEFINITE).also {

--- a/app/src/main/java/at/bitfire/icsdroid/ui/CalendarListActivity.kt
+++ b/app/src/main/java/at/bitfire/icsdroid/ui/CalendarListActivity.kt
@@ -6,13 +6,11 @@ package at.bitfire.icsdroid.ui
 
 import android.annotation.SuppressLint
 import android.app.Application
-import android.content.ContentUris
 import android.content.Context
 import android.content.Intent
 import android.os.Build
 import android.os.Bundle
 import android.os.PowerManager
-import android.provider.CalendarContract
 import android.provider.Settings
 import android.util.Log
 import android.view.*
@@ -65,20 +63,20 @@ class CalendarListActivity: AppCompatActivity(), SwipeRefreshLayout.OnRefreshLis
         }
 
         // calendars
-        val calendarAdapter = CalendarListAdapter(this)
-        calendarAdapter.clickListener = { calendar ->
+        val subscriptionAdapter = SubscriptionListAdapter(this)
+        subscriptionAdapter.clickListener = { calendar ->
             val intent = Intent(this, EditCalendarActivity::class.java)
-            intent.data = ContentUris.withAppendedId(CalendarContract.Calendars.CONTENT_URI, calendar.id)
+            intent.putExtra(EditCalendarActivity.EXTRA_SUBSCRIPTION_ID, calendar.id)
             startActivity(intent)
         }
-        binding.calendarList.adapter = calendarAdapter
+        binding.calendarList.adapter = subscriptionAdapter
 
         binding.fab.setOnClickListener {
             onAddCalendar()
         }
 
         model.subscriptions.observe(this) { subscriptions ->
-            calendarAdapter.submitList(subscriptions)
+            subscriptionAdapter.submitList(subscriptions)
 
             val colors = mutableSetOf<Int>()
             colors += defaultRefreshColor
@@ -177,28 +175,26 @@ class CalendarListActivity: AppCompatActivity(), SwipeRefreshLayout.OnRefreshLis
     }
 
 
-    class CalendarListAdapter(
-            val context: Context
-    ): ListAdapter<Subscription, CalendarListAdapter.ViewHolder>(object: DiffUtil.ItemCallback<Subscription>() {
+    class SubscriptionListAdapter(
+        val context: Context
+    ): ListAdapter<Subscription, SubscriptionListAdapter.ViewHolder>(object: DiffUtil.ItemCallback<Subscription>() {
 
         override fun areItemsTheSame(oldItem: Subscription, newItem: Subscription) =
-                oldItem.id == newItem.id
+            oldItem.id == newItem.id
 
         override fun areContentsTheSame(oldItem: Subscription, newItem: Subscription) =
-                // compare all displayed fields
-                oldItem.url == newItem.url &&
-                oldItem.displayName == newItem.displayName &&
-                oldItem.lastSync == newItem.lastSync &&
-                oldItem.color == newItem.color &&
-                oldItem.errorMessage == newItem.errorMessage
+            // compare all displayed fields
+            oldItem.url == newItem.url &&
+            oldItem.displayName == newItem.displayName &&
+            oldItem.lastSync == newItem.lastSync &&
+            oldItem.color == newItem.color &&
+            oldItem.errorMessage == newItem.errorMessage
 
     }) {
 
         class ViewHolder(val binding: CalendarListItemBinding): RecyclerView.ViewHolder(binding.root)
 
-
         var clickListener: ((Subscription) -> Unit)? = null
-
 
         override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ViewHolder {
             Log.i(Constants.TAG, "Creating view holder")

--- a/app/src/main/java/at/bitfire/icsdroid/ui/CalendarListActivity.kt
+++ b/app/src/main/java/at/bitfire/icsdroid/ui/CalendarListActivity.kt
@@ -46,7 +46,6 @@ class CalendarListActivity: AppCompatActivity(), SwipeRefreshLayout.OnRefreshLis
 
     private var snackBar: Snackbar? = null
 
-
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setTitle(R.string.title_activity_calendar_list)
@@ -241,18 +240,18 @@ class CalendarListActivity: AppCompatActivity(), SwipeRefreshLayout.OnRefreshLis
 
     }
 
-    /** Data model for this view. Updates calendar subscriptions in real-time. */
     class SubscriptionsModel(application: Application): AndroidViewModel(application) {
+
         /** whether there are running sync workers */
         val isRefreshing = Transformations.map(SyncWorker.liveStatus(application)) { workInfos ->
             workInfos.any { it.state == WorkInfo.State.RUNNING }
         }
 
-        private val database = AppDatabase.getInstance(application)
-        private val subscriptionsDao = database.subscriptionsDao()
+        /** LiveData watching the subscriptions */
+        val subscriptions = AppDatabase.getInstance(application)
+            .subscriptionsDao()
+            .getAllLive()
 
-        /** A LiveData that watches the subscriptions. */
-        val subscriptions = subscriptionsDao.getAllLive()
     }
 
 }

--- a/app/src/main/java/at/bitfire/icsdroid/ui/CalendarListActivity.kt
+++ b/app/src/main/java/at/bitfire/icsdroid/ui/CalendarListActivity.kt
@@ -65,20 +65,6 @@ class CalendarListActivity: AppCompatActivity(), SwipeRefreshLayout.OnRefreshLis
         binding.refresh.setOnRefreshListener(this)
         binding.refresh.setSize(SwipeRefreshLayout.LARGE)
 
-        val permissionsRequestLauncher =
-            PermissionUtils.registerPermissionRequest(this, CalendarModel.REQUIRED_PERMISSIONS, R.string.permissions_required) {
-                // re-initialize model if calendar permissions are granted
-                model.reinit()
-
-                // we have calendar permissions, cancel possible sync notification (see SyncAdapter.onSecurityException askPermissionsIntent)
-                val nm = NotificationManagerCompat.from(this)
-                nm.cancel(NotificationUtils.NOTIFY_PERMISSION)
-            }
-        model.askForPermissions.observe(this) { ask ->
-            if (ask)
-                permissionsRequestLauncher()
-        }
-
         // show whether sync is running
         model.isRefreshing.observe(this) { isRefreshing ->
             binding.refresh.isRefreshing = isRefreshing

--- a/app/src/main/java/at/bitfire/icsdroid/ui/CalendarListActivity.kt
+++ b/app/src/main/java/at/bitfire/icsdroid/ui/CalendarListActivity.kt
@@ -40,7 +40,10 @@ import java.util.*
 class CalendarListActivity: AppCompatActivity(), SwipeRefreshLayout.OnRefreshListener {
 
     companion object {
-        const val EXTRA_PERMISSION = "permission"
+        /**
+         * Set this extra to request calendar permission when the activity starts.
+         */
+        const val EXTRA_REQUEST_CALENDAR_PERMISSION = "permission"
     }
 
     private val model by viewModels<SubscriptionsModel>()
@@ -94,10 +97,9 @@ class CalendarListActivity: AppCompatActivity(), SwipeRefreshLayout.OnRefreshLis
         }
 
         // If EXTRA_PERMISSION is true, request the calendar permissions
-        val requestPermissions = intent.getBooleanExtra(EXTRA_PERMISSION, false)
-        if (requestPermissions && !PermissionUtils.haveCalendarPermissions(this)) {
+        val requestPermissions = intent.getBooleanExtra(EXTRA_REQUEST_CALENDAR_PERMISSION, false)
+        if (requestPermissions && !PermissionUtils.haveCalendarPermissions(this))
             requestCalendarPermissions()
-        }
 
         model.subscriptions.observe(this) { subscriptions ->
             subscriptionAdapter.submitList(subscriptions)
@@ -157,13 +159,6 @@ class CalendarListActivity: AppCompatActivity(), SwipeRefreshLayout.OnRefreshLis
                 snackBar = Snackbar.make(binding.coordinator, R.string.calendar_permissions_required, Snackbar.LENGTH_INDEFINITE)
                     .setAction(R.string.permissions_grant) { requestCalendarPermissions() }
                     .also { it.show() }
-            }
-
-            // periodic sync not enabled
-            AppAccount.syncInterval(this) == AppAccount.SYNC_INTERVAL_MANUALLY -> {
-                snackBar = Snackbar.make(binding.coordinator, R.string.calendar_list_sync_interval_manually, Snackbar.LENGTH_INDEFINITE).also {
-                    it.show()
-                }
             }
 
             // periodic sync enabled AND Android >= 6 AND not whitelisted from battery saving AND sync interval < 1 day

--- a/app/src/main/java/at/bitfire/icsdroid/ui/NotificationUtils.kt
+++ b/app/src/main/java/at/bitfire/icsdroid/ui/NotificationUtils.kt
@@ -8,7 +8,9 @@ import android.app.NotificationChannel
 import android.app.NotificationManager
 import android.app.PendingIntent
 import android.content.Context
+import android.content.Intent
 import android.os.Build
+import androidx.core.app.NotificationCompat
 import at.bitfire.icsdroid.R
 
 object NotificationUtils {
@@ -34,6 +36,27 @@ object NotificationUtils {
         }
 
         return nm
+    }
+
+    /**
+     * Shows a notification informing the user that the calendar permission is required but has not
+     * been granted.
+     */
+    fun showCalendarPermissionNotification(context: Context) {
+        val nm = createChannels(context)
+        val askPermissionsIntent = Intent(context, CalendarListActivity::class.java).apply {
+            putExtra(CalendarListActivity.EXTRA_PERMISSION, true)
+        }
+        val notification = NotificationCompat.Builder(context, CHANNEL_SYNC)
+            .setSmallIcon(R.drawable.ic_sync_problem_white)
+            .setContentTitle(context.getString(R.string.sync_permission_required))
+            .setContentText(context.getString(R.string.sync_permission_required_sync_calendar))
+            .setCategory(NotificationCompat.CATEGORY_ERROR)
+            .setContentIntent(PendingIntent.getActivity(context, 0, askPermissionsIntent, PendingIntent.FLAG_UPDATE_CURRENT + NotificationUtils.flagImmutableCompat))
+            .setAutoCancel(true)
+            .setLocalOnly(true)
+            .build()
+        nm.notify(NOTIFY_PERMISSION, notification)
     }
 
 }

--- a/app/src/main/java/at/bitfire/icsdroid/ui/NotificationUtils.kt
+++ b/app/src/main/java/at/bitfire/icsdroid/ui/NotificationUtils.kt
@@ -45,7 +45,7 @@ object NotificationUtils {
     fun showCalendarPermissionNotification(context: Context) {
         val nm = createChannels(context)
         val askPermissionsIntent = Intent(context, CalendarListActivity::class.java).apply {
-            putExtra(CalendarListActivity.EXTRA_PERMISSION, true)
+            putExtra(CalendarListActivity.EXTRA_REQUEST_CALENDAR_PERMISSION, true)
         }
         val notification = NotificationCompat.Builder(context, CHANNEL_SYNC)
             .setSmallIcon(R.drawable.ic_sync_problem_white)

--- a/app/src/main/res/layout/calendar_list_activity.xml
+++ b/app/src/main/res/layout/calendar_list_activity.xml
@@ -5,7 +5,7 @@
     tools:context=".ui.CalendarListActivity">
 
     <data>
-        <variable name="model" type="at.bitfire.icsdroid.ui.CalendarListActivity.CalendarModel" />
+        <variable name="model" type="at.bitfire.icsdroid.ui.CalendarListActivity.SubscriptionsModel" />
         <import type="android.view.View" />
     </data>
 
@@ -25,7 +25,7 @@
                 android:layout_width="match_parent"
                 android:layout_height="match_parent"
                 app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
-                android:visibility="@{model.calendars.empty ? View.GONE : View.VISIBLE }" />
+                android:visibility="@{model.subscriptions.empty ? View.GONE : View.VISIBLE }" />
 
         </androidx.swiperefreshlayout.widget.SwipeRefreshLayout>
 
@@ -37,7 +37,7 @@
             style="@style/TextAppearance.MaterialComponents.Body1"
             android:layout_margin="16dp"
             android:text="@string/calendar_list_empty_info"
-            android:visibility="@{model.calendars.empty ? View.VISIBLE : View.GONE }" />
+            android:visibility="@{model.subscriptions.empty ? View.VISIBLE : View.GONE }" />
 
         <com.google.android.material.floatingactionbutton.FloatingActionButton
             android:id="@+id/fab"

--- a/app/src/main/res/layout/edit_calendar.xml
+++ b/app/src/main/res/layout/edit_calendar.xml
@@ -19,13 +19,6 @@
                 android:layout_height="wrap_content"
                 android:name="at.bitfire.icsdroid.ui.TitleColorFragment"/>
 
-            <com.google.android.material.switchmaterial.SwitchMaterial
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="16dp"
-                android:checked="@={model.active}"
-                android:text="@string/edit_calendar_sync_this_calendar" />
-
             <androidx.fragment.app.FragmentContainerView
                 android:id="@id/credentials"
                 android:layout_width="match_parent"

--- a/app/src/main/res/layout/edit_calendar.xml
+++ b/app/src/main/res/layout/edit_calendar.xml
@@ -1,6 +1,6 @@
 <layout xmlns:android="http://schemas.android.com/apk/res/android">
     <data>
-        <variable name="model" type="at.bitfire.icsdroid.ui.EditCalendarActivity.CalendarModel"/>
+        <variable name="model" type="at.bitfire.icsdroid.ui.EditCalendarActivity.SubscriptionModel"/>
     </data>
 
     <ScrollView

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -11,6 +11,7 @@
     <string name="could_not_load_calendar">Couldn\'t load calendar</string>
     <string name="notification_channel_sync_problem">Sync problems</string>
     <string name="permissions_required">Permissions required</string>
+    <string name="permissions_grant">Grant</string>
 
     <!-- CalendarListActivity -->
     <string name="title_activity_calendar_list">My subscriptions</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -21,9 +21,6 @@
     <string name="calendar_list_not_synced_yet">not synchronized yet</string>
     <string name="calendar_list_set_sync_interval">Set sync. interval</string>
     <string name="calendar_list_sync_disabled">Sync. disabled</string>
-    <string name="calendar_list_sync_interval_manually">Automatic sync disabled</string>
-    <string name="calendar_list_master_sync_disabled">System-wide automatic sync is disabled</string>
-    <string name="calendar_list_master_sync_enable">Activate</string>
     <string name="calendar_list_battery_whitelist">Battery: Whitelist ICSx⁵ for short sync intervals</string>
     <string name="calendar_list_battery_whitelist_settings">Settings</string>
     <!-- settings, currently in CalendarListActivity -->

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -8,6 +8,7 @@
     <!-- common strings -->
     <string name="action_next">Next</string>
     <string name="calendar_permissions_required">Calendar permissions required</string>
+    <string name="notification_permissions_required">Notification permissions required</string>
     <string name="could_not_load_calendar">Couldn\'t load calendar</string>
     <string name="notification_channel_sync_problem">Sync problems</string>
     <string name="permissions_required">Permissions required</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -20,7 +20,6 @@
     <string name="calendar_list_info">About ICSx⁵</string>
     <string name="calendar_list_not_synced_yet">not synchronized yet</string>
     <string name="calendar_list_set_sync_interval">Set sync. interval</string>
-    <string name="calendar_list_sync_disabled">Sync. disabled</string>
     <string name="calendar_list_battery_whitelist">Battery: Whitelist ICSx⁵ for short sync intervals</string>
     <string name="calendar_list_battery_whitelist_settings">Settings</string>
     <!-- settings, currently in CalendarListActivity -->

--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ buildscript {
         kotlin: '1.7.20',
         okhttp: '5.0.0-alpha.10',
         ksp: '1.0.7',
-        room: '2.4.3'
+        room: '2.5.0'
     ]
 
     repositories {


### PR DESCRIPTION
I've created this first PR for #110, but there's no way to test it without migrating `AddCalendarActivity` first, at least. Should I join this PR with the update of this activity; merge this, and then create a new PR; or how should I continue? @rfc2822 

Note: I have removed the permission request for simplifying the view model.

# Breaking changes
Since `Subscription` doesn't have the `isSynced` field, `R.string.calendar_list_sync_disabled` is no longer displayed. We should remember to remove this string if finally no longer used.

The same happens for `R.string.edit_calendar_sync_this_calendar`.