### PR TITLE
Large runners

### DIFF
--- a/.github/workflows/test-dev.yml
+++ b/.github/workflows/test-dev.yml
@@ -61,6 +61,7 @@ jobs:
         uses: reactivecircus/android-emulator-runner@v2
         with:
           api-level: ${{ matrix.api-level }}
+          arch: x86_64
           force-avd-creation: false
           emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
           disable-animations: false
@@ -70,6 +71,7 @@ jobs:
         uses: reactivecircus/android-emulator-runner@v2
         with:
           api-level: ${{ matrix.api-level }}
+          arch: x86_64
           force-avd-creation: false
           emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
           disable-animations: true

--- a/.github/workflows/test-dev.yml
+++ b/.github/workflows/test-dev.yml
@@ -27,13 +27,10 @@ jobs:
 
   test_on_emulator:
     name: Tests with emulator
-    runs-on: privileged
-    container:
-      image: ghcr.io/bitfireat/docker-android-ci:main
-      options: --privileged
-      env:
-        ANDROID_HOME: /sdk
-        ANDROID_AVD_HOME: /root/.android/avd
+    runs-on: ubuntu-latest-4-cores
+    strategy:
+      matrix:
+        api-level: [31]
     steps:
       - uses: actions/checkout@v2
         with:
@@ -42,13 +39,42 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: 11
-          cache: 'gradle'
-      - uses: gradle/wrapper-validation-action@v1
+      - uses: gradle/gradle-build-action@v2
 
-      - name: Start emulator
-        run: start-emulator.sh
-      - name: Run connected tests
-        run: ./gradlew --no-daemon app:connectedStandardDebugAndroidTest
+      - name: Enable KVM group perms
+        run: |
+            echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+            sudo udevadm control --reload-rules
+            sudo udevadm trigger --name-match=kvm
+
+      - name: Cache AVD
+        uses: actions/cache@v3
+        id: avd-cache
+        with:
+          path: |
+            ~/.android/avd/*
+            ~/.android/adb*
+          key: avd-${{ matrix.api-level }}
+
+      - name: Create AVD and generate snapshot for caching
+        if: steps.avd-cache.outputs.cache-hit != 'true'
+        uses: reactivecircus/android-emulator-runner@v2
+        with:
+          api-level: ${{ matrix.api-level }}
+          force-avd-creation: false
+          emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
+          disable-animations: false
+          script: echo "Generated AVD snapshot for caching."
+
+      - name: Run tests
+        uses: reactivecircus/android-emulator-runner@v2
+        with:
+          api-level: ${{ matrix.api-level }}
+          force-avd-creation: false
+          emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
+          disable-animations: true
+          script: ./gradlew --no-daemon app:connectedStandardDebugAndroidTest
+
       - name: Archive results
         if: always()
         uses: actions/upload-artifact@v2


### PR DESCRIPTION
Run CI tests on Large runners to get independent of the self-hosted runner, which shouldn't be used for public repos.