### PR TITLE
Upgraded Compose Dependencies

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -105,7 +105,7 @@ dependencies {
     implementation 'com.github.bitfireAT:cert4android:3817e62d9f173d8f8b800d24769f42cb205f560e'
     implementation 'com.github.bitfireAT:ical4android:a78e72f580'
 
-    implementation 'androidx.activity:activity-compose:1.7.1'
+    implementation 'androidx.activity:activity-compose:1.7.2'
     implementation 'androidx.appcompat:appcompat:1.6.1'
     implementation 'androidx.cardview:cardview:1.0.0'
     implementation 'androidx.core:core-ktx:1.10.1'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -123,7 +123,7 @@ dependencies {
     implementation 'androidx.compose.material:material'
     debugImplementation "androidx.compose.ui:ui-tooling"
     implementation "androidx.compose.ui:ui-tooling-preview"
-    implementation "androidx.compose.runtime:runtime-livedata:1.4.3"
+    implementation "androidx.compose.runtime:runtime-livedata:1.5.0"
     implementation 'com.google.accompanist:accompanist-themeadapter-material:0.30.1'
     implementation 'io.github.vanpra.compose-material-dialogs:color:0.9.0'
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 buildscript {
     ext.versions = [
         aboutLibs: '10.7.0',
-        composeBom: '2023.05.01',   // https://developer.android.com/jetpack/compose/bom
+        composeBom: '2023.08.00',   // https://developer.android.com/jetpack/compose/bom
         kotlin: '1.8.21',           // keep in sync with app/build.gradle composeOptions.kotlinCompilerExtensionVersion
         ksp: '1.0.11',
         okhttp: '5.0.0-alpha.11',


### PR DESCRIPTION
Relevant changes are:
- Added primitive versions of the State API, allowing Int, Long, Float, and Double values to be tracked in State objects without incurring penalties for autoboxing. Use the new factory methods mutableIntState(Int), mutableFloatStateOf(Float), etc in order to use these. ([I48e43](https://android-review.googlesource.com/#/q/I48e438d0af15226217b77b2ba9a970c3219580bf))

We are not using any of them since we use LiveData in ViewModel.

Depends on #175