### PR TITLE
Fixed adding local files

### DIFF
--- a/app/src/main/java/at/bitfire/icsdroid/ui/views/AddCalendarActivity.kt
+++ b/app/src/main/java/at/bitfire/icsdroid/ui/views/AddCalendarActivity.kt
@@ -81,7 +81,7 @@ class AddCalendarActivity : AppCompatActivity() {
                     Intent.FLAG_GRANT_READ_URI_PERMISSION
                 )
 
-                subscriptionSettingsModel.url.value = uri.toString()
+                subscriptionSettingsModel.url.postValue(uri.toString())
             }
         }
 


### PR DESCRIPTION
I think the issue is that when loading the file the activity has been paused, so the update is not received by Compose. If we update the state by posting instead of setting the value, the update is delayed a bit, giving time for Compose to boot back up