### PR TITLE
Switch to compose state and kotlin flows - 2. iteration

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -125,6 +125,7 @@ dependencies {
     implementation(libs.androidx.appCompat)
     implementation(libs.androidx.core)
     implementation(libs.androidx.lifecycle.viewmodel)
+    implementation(libs.androidx.lifecycle.runtime.compose)
     implementation(libs.androidx.work.runtime)
 
     // Jetpack Compose

--- a/app/src/androidTest/java/at/bitfire/icsdroid/model/ValidationModelTest.kt
+++ b/app/src/androidTest/java/at/bitfire/icsdroid/model/ValidationModelTest.kt
@@ -104,7 +104,7 @@ class ValidationModelTest {
             model.validate(server.url("/").toAndroidUri(), null, null).join()
         }
 
-        return model.result.value!!
+        return model.uiState.result!!
     }
 
 }

--- a/app/src/main/java/at/bitfire/icsdroid/model/CreateSubscriptionModel.kt
+++ b/app/src/main/java/at/bitfire/icsdroid/model/CreateSubscriptionModel.kt
@@ -39,17 +39,17 @@ class CreateSubscriptionModel(application: Application) : AndroidViewModel(appli
                     displayName = subscriptionSettingsModel.title.value!!,
                     url = Uri.parse(subscriptionSettingsModel.url.value),
                     color = subscriptionSettingsModel.color.value,
-                    ignoreEmbeddedAlerts = subscriptionSettingsModel.ignoreAlerts.value ?: false,
+                    ignoreEmbeddedAlerts = subscriptionSettingsModel.ignoreAlerts.value,
                     defaultAlarmMinutes = subscriptionSettingsModel.defaultAlarmMinutes.value,
                     defaultAllDayAlarmMinutes = subscriptionSettingsModel.defaultAllDayAlarmMinutes.value,
-                    ignoreDescription = subscriptionSettingsModel.ignoreDescription.value ?: false,
+                    ignoreDescription = subscriptionSettingsModel.ignoreDescription.value,
                 )
 
                 /** A list of all the ids of the inserted rows */
                 val id = subscriptionsDao.add(subscription)
 
                 // Create the credential in the IO thread
-                if (credentialsModel.requiresAuth.value == true) {
+                if (credentialsModel.requiresAuth.value) {
                     // If the subscription requires credentials, create them
                     val username = credentialsModel.username.value
                     val password = credentialsModel.password.value

--- a/app/src/main/java/at/bitfire/icsdroid/model/CreateSubscriptionModel.kt
+++ b/app/src/main/java/at/bitfire/icsdroid/model/CreateSubscriptionModel.kt
@@ -3,8 +3,8 @@ package at.bitfire.icsdroid.model
 import android.app.Application
 import android.net.Uri
 import android.util.Log
+import androidx.compose.runtime.mutableStateOf
 import androidx.lifecycle.AndroidViewModel
-import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.viewModelScope
 import at.bitfire.icsdroid.Constants
 import at.bitfire.icsdroid.SyncWorker
@@ -20,10 +20,10 @@ class CreateSubscriptionModel(application: Application) : AndroidViewModel(appli
     private val subscriptionsDao = database.subscriptionsDao()
     private val credentialsDao = database.credentialsDao()
 
-    val success = MutableLiveData(false)
-    val errorMessage = MutableLiveData<String?>(null)
-    val isCreating = MutableLiveData(false)
-    val showNextButton = MutableLiveData(false)
+    val success = mutableStateOf(false)
+    val errorMessage = mutableStateOf<String?>(null)
+    val isCreating = mutableStateOf(false)
+    val showNextButton = mutableStateOf(false)
 
     /**
      * Creates a new subscription taking the data from the given models.
@@ -33,7 +33,7 @@ class CreateSubscriptionModel(application: Application) : AndroidViewModel(appli
         credentialsModel: CredentialsModel,
     ) {
         viewModelScope.launch(Dispatchers.IO) {
-            isCreating.postValue(true)
+            isCreating.value = true
             try {
                 val subscription = Subscription(
                     displayName = subscriptionSettingsModel.title.value!!,
@@ -66,12 +66,12 @@ class CreateSubscriptionModel(application: Application) : AndroidViewModel(appli
                 // sync the subscription to reflect the changes in the calendar provider
                 SyncWorker.run(getApplication())
 
-                success.postValue(true)
+                success.value = true
             } catch (e: Exception) {
                 Log.e(Constants.TAG, "Couldn't create calendar", e)
-                errorMessage.postValue(e.localizedMessage ?: e.message)
+                errorMessage.value = e.localizedMessage ?: e.message
             } finally {
-                isCreating.postValue(false)
+                isCreating.value = false
             }
         }
     }

--- a/app/src/main/java/at/bitfire/icsdroid/model/CredentialsModel.kt
+++ b/app/src/main/java/at/bitfire/icsdroid/model/CredentialsModel.kt
@@ -1,15 +1,15 @@
 package at.bitfire.icsdroid.model
 
-import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import at.bitfire.icsdroid.db.entity.Credential
+import kotlinx.coroutines.flow.MutableStateFlow
 
 class CredentialsModel : ViewModel() {
-    val requiresAuth = MutableLiveData(false)
-    val username = MutableLiveData<String?>(null)
-    val password = MutableLiveData<String?>(null)
+    val requiresAuth = MutableStateFlow(false)
+    val username = MutableStateFlow<String?>(null)
+    val password = MutableStateFlow<String?>(null)
 
-    val isInsecure = MutableLiveData(false)
+    val isInsecure = MutableStateFlow(false)
 
     fun equalsCredential(credential: Credential) =
         username.value == credential.username

--- a/app/src/main/java/at/bitfire/icsdroid/model/EditSubscriptionModel.kt
+++ b/app/src/main/java/at/bitfire/icsdroid/model/EditSubscriptionModel.kt
@@ -1,7 +1,9 @@
 package at.bitfire.icsdroid.model
 
 import android.app.Application
+import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
 import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.viewModelScope
 import at.bitfire.icsdroid.R
@@ -20,7 +22,12 @@ class EditSubscriptionModel(
     private val credentialsDao = db.credentialsDao()
     private val subscriptionsDao = db.subscriptionsDao()
 
-    val successMessage = mutableStateOf<String?>(null)
+    data class UiState(
+        val successMessage: String? = null
+    )
+
+    var uiState by mutableStateOf(UiState())
+        private set
 
     val subscriptionWithCredential = db.subscriptionsDao().getWithCredentialsByIdLive(subscriptionId)
 
@@ -54,7 +61,7 @@ class EditSubscriptionModel(
                     credentialsDao.removeBySubscriptionId(subscriptionId)
 
                 // notify UI about success
-                successMessage.value = getApplication<Application>().getString(R.string.edit_calendar_saved)
+                uiState = uiState.copy(successMessage = getApplication<Application>().getString(R.string.edit_calendar_saved))
 
                 // sync the subscription to reflect the changes in the calendar provider
                 SyncWorker.run(getApplication(), forceResync = true)
@@ -74,7 +81,7 @@ class EditSubscriptionModel(
                 SyncWorker.run(getApplication())
 
                 // notify UI about success
-                successMessage.value = getApplication<Application>().getString(R.string.edit_calendar_deleted)
+                uiState = uiState.copy(successMessage = getApplication<Application>().getString(R.string.edit_calendar_deleted))
             }
         }
     }

--- a/app/src/main/java/at/bitfire/icsdroid/model/EditSubscriptionModel.kt
+++ b/app/src/main/java/at/bitfire/icsdroid/model/EditSubscriptionModel.kt
@@ -40,12 +40,12 @@ class EditSubscriptionModel(
                     color = subscriptionSettingsModel.color.value,
                     defaultAlarmMinutes = subscriptionSettingsModel.defaultAlarmMinutes.value,
                     defaultAllDayAlarmMinutes = subscriptionSettingsModel.defaultAllDayAlarmMinutes.value,
-                    ignoreEmbeddedAlerts = subscriptionSettingsModel.ignoreAlerts.value ?: false,
-                    ignoreDescription = subscriptionSettingsModel.ignoreDescription.value ?: false
+                    ignoreEmbeddedAlerts = subscriptionSettingsModel.ignoreAlerts.value,
+                    ignoreDescription = subscriptionSettingsModel.ignoreDescription.value
                 )
                 subscriptionsDao.update(newSubscription)
 
-                if (credentialsModel.requiresAuth.value == true) {
+                if (credentialsModel.requiresAuth.value) {
                     val username = credentialsModel.username.value
                     val password = credentialsModel.password.value
                     if (username != null && password != null)

--- a/app/src/main/java/at/bitfire/icsdroid/model/EditSubscriptionModel.kt
+++ b/app/src/main/java/at/bitfire/icsdroid/model/EditSubscriptionModel.kt
@@ -1,8 +1,8 @@
 package at.bitfire.icsdroid.model
 
 import android.app.Application
+import androidx.compose.runtime.mutableStateOf
 import androidx.lifecycle.AndroidViewModel
-import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.viewModelScope
 import at.bitfire.icsdroid.R
 import at.bitfire.icsdroid.SyncWorker
@@ -20,7 +20,7 @@ class EditSubscriptionModel(
     private val credentialsDao = db.credentialsDao()
     private val subscriptionsDao = db.subscriptionsDao()
 
-    val successMessage = MutableLiveData<String>()
+    val successMessage = mutableStateOf<String?>(null)
 
     val subscriptionWithCredential = db.subscriptionsDao().getWithCredentialsByIdLive(subscriptionId)
 
@@ -54,7 +54,7 @@ class EditSubscriptionModel(
                     credentialsDao.removeBySubscriptionId(subscriptionId)
 
                 // notify UI about success
-                successMessage.postValue(getApplication<Application>().getString(R.string.edit_calendar_saved))
+                successMessage.value = getApplication<Application>().getString(R.string.edit_calendar_saved)
 
                 // sync the subscription to reflect the changes in the calendar provider
                 SyncWorker.run(getApplication(), forceResync = true)
@@ -74,7 +74,7 @@ class EditSubscriptionModel(
                 SyncWorker.run(getApplication())
 
                 // notify UI about success
-                successMessage.postValue(getApplication<Application>().getString(R.string.edit_calendar_deleted))
+                successMessage.value = getApplication<Application>().getString(R.string.edit_calendar_deleted)
             }
         }
     }

--- a/app/src/main/java/at/bitfire/icsdroid/model/ValidationModel.kt
+++ b/app/src/main/java/at/bitfire/icsdroid/model/ValidationModel.kt
@@ -7,8 +7,8 @@ package at.bitfire.icsdroid.model
 import android.app.Application
 import android.net.Uri
 import android.util.Log
+import androidx.compose.runtime.mutableStateOf
 import androidx.lifecycle.AndroidViewModel
-import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.viewModelScope
 import at.bitfire.ical4android.Css3Color
 import at.bitfire.ical4android.Event
@@ -27,9 +27,8 @@ import okhttp3.MediaType
 
 class ValidationModel(application: Application): AndroidViewModel(application) {
 
-    val isVerifyingUrl = MutableLiveData(false)
-
-    val result = MutableLiveData<ResourceInfo?>(null)
+    val isVerifyingUrl = mutableStateOf(false)
+    val result = mutableStateOf<ResourceInfo?>(null)
 
     fun validate(
         originalUri: Uri,
@@ -39,7 +38,7 @@ class ValidationModel(application: Application): AndroidViewModel(application) {
         try {
             Log.i(Constants.TAG, "Validating Webcal feed $originalUri (authentication: $username)")
 
-            isVerifyingUrl.postValue(true)
+            isVerifyingUrl.value = true
 
             val info = ResourceInfo(originalUri)
             val downloader = object: CalendarFetcher(getApplication(), originalUri) {
@@ -72,7 +71,7 @@ class ValidationModel(application: Application): AndroidViewModel(application) {
                         info.eventsFound = events.size
                     }
 
-                    result.postValue(info)
+                    result.value = info
                 }
 
                 override suspend fun onNewPermanentUrl(target: Uri) {
@@ -84,7 +83,7 @@ class ValidationModel(application: Application): AndroidViewModel(application) {
                 override suspend fun onError(error: Exception) {
                     Log.e(Constants.TAG, "Couldn't validate calendar", error)
                     info.exception = error
-                    result.postValue(info)
+                    result.value = info
                 }
             }
 
@@ -96,7 +95,7 @@ class ValidationModel(application: Application): AndroidViewModel(application) {
 
             downloader.fetch()
         } finally {
-            isVerifyingUrl.postValue(false)
+            isVerifyingUrl.value = false
         }
     }
 

--- a/app/src/main/java/at/bitfire/icsdroid/model/ValidationModel.kt
+++ b/app/src/main/java/at/bitfire/icsdroid/model/ValidationModel.kt
@@ -7,7 +7,9 @@ package at.bitfire.icsdroid.model
 import android.app.Application
 import android.net.Uri
 import android.util.Log
+import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
 import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.viewModelScope
 import at.bitfire.ical4android.Css3Color
@@ -18,17 +20,26 @@ import at.bitfire.icsdroid.Constants
 import at.bitfire.icsdroid.HttpUtils.toURI
 import at.bitfire.icsdroid.HttpUtils.toUri
 import at.bitfire.icsdroid.ui.ResourceInfo
-import java.io.InputStream
-import java.io.InputStreamReader
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import net.fortuna.ical4j.model.property.Color
 import okhttp3.MediaType
+import java.io.InputStream
+import java.io.InputStreamReader
 
 class ValidationModel(application: Application): AndroidViewModel(application) {
 
-    val isVerifyingUrl = mutableStateOf(false)
-    val result = mutableStateOf<ResourceInfo?>(null)
+    data class UiState(
+        val isVerifyingUrl: Boolean = false,
+        val result: ResourceInfo? = null
+    )
+
+    var uiState by mutableStateOf(UiState())
+        private set
+
+    fun resetResult() {
+        uiState = uiState.copy(result = null)
+    }
 
     fun validate(
         originalUri: Uri,
@@ -38,7 +49,7 @@ class ValidationModel(application: Application): AndroidViewModel(application) {
         try {
             Log.i(Constants.TAG, "Validating Webcal feed $originalUri (authentication: $username)")
 
-            isVerifyingUrl.value = true
+            uiState = uiState.copy(isVerifyingUrl = true)
 
             val info = ResourceInfo(originalUri)
             val downloader = object: CalendarFetcher(getApplication(), originalUri) {
@@ -71,7 +82,7 @@ class ValidationModel(application: Application): AndroidViewModel(application) {
                         info.eventsFound = events.size
                     }
 
-                    result.value = info
+                    uiState = uiState.copy(result = info)
                 }
 
                 override suspend fun onNewPermanentUrl(target: Uri) {
@@ -83,7 +94,7 @@ class ValidationModel(application: Application): AndroidViewModel(application) {
                 override suspend fun onError(error: Exception) {
                     Log.e(Constants.TAG, "Couldn't validate calendar", error)
                     info.exception = error
-                    result.value = info
+                    uiState = uiState.copy(result = info)
                 }
             }
 
@@ -95,7 +106,7 @@ class ValidationModel(application: Application): AndroidViewModel(application) {
 
             downloader.fetch()
         } finally {
-            isVerifyingUrl.value = false
+            uiState = uiState.copy(isVerifyingUrl = false)
         }
     }
 

--- a/app/src/main/java/at/bitfire/icsdroid/service/ComposableStartupService.kt
+++ b/app/src/main/java/at/bitfire/icsdroid/service/ComposableStartupService.kt
@@ -6,7 +6,7 @@ package at.bitfire.icsdroid.service
 
 import androidx.appcompat.app.AppCompatActivity
 import androidx.compose.runtime.Composable
-import androidx.lifecycle.LiveData
+import androidx.compose.runtime.State
 
 /**
  * Used for interactions between flavors.
@@ -23,10 +23,10 @@ interface ComposableStartupService {
 
     /**
      * Provides a stateful response to whether this composable should be shown or not.
-     * @return A [LiveData] that can be observed, and will make [Content] visible when `true`.
+     * @return A [State] that can be observed, and will make [Content] visible when `true`.
      */
     @Composable
-    fun shouldShow(): LiveData<Boolean>
+    fun shouldShow(): State<Boolean>
 
     /**
      * The content to display. It's not constrained, will be rendered together with the main UI.

--- a/app/src/main/java/at/bitfire/icsdroid/ui/views/AddCalendarActivity.kt
+++ b/app/src/main/java/at/bitfire/icsdroid/ui/views/AddCalendarActivity.kt
@@ -41,7 +41,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.livedata.observeAsState
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -121,8 +120,8 @@ class AddCalendarActivity : AppCompatActivity() {
             val password: String? by credentialsModel.password.collectAsState()
             val isInsecure: Boolean by credentialsModel.isInsecure.collectAsState()
 
-            val isVerifyingUrl: Boolean by validationModel.isVerifyingUrl.observeAsState(false)
-            val validationResult: ResourceInfo? by validationModel.result.observeAsState(null)
+            val isVerifyingUrl: Boolean by validationModel.isVerifyingUrl
+            val validationResult: ResourceInfo? by validationModel.result
 
             val success by subscriptionModel.success
             val errorMessage by subscriptionModel.errorMessage
@@ -294,7 +293,7 @@ class AddCalendarActivity : AppCompatActivity() {
                         // otherwise, go back a page
                         else scope.launch {
                             // Needed for non-first-time validations to trigger following validation result updates
-                            validationModel.result.postValue(null)
+                            validationModel.result.value = null
                             pagerState.animateScrollToPage(pagerState.currentPage - 1)
                         }
                     }

--- a/app/src/main/java/at/bitfire/icsdroid/ui/views/AddCalendarActivity.kt
+++ b/app/src/main/java/at/bitfire/icsdroid/ui/views/AddCalendarActivity.kt
@@ -39,7 +39,6 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
@@ -48,6 +47,7 @@ import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import at.bitfire.icsdroid.Constants
 import at.bitfire.icsdroid.HttpClient
 import at.bitfire.icsdroid.R
@@ -104,21 +104,21 @@ class AddCalendarActivity : AppCompatActivity() {
             val context = LocalContext.current
             val pagerState = rememberPagerState { 2 }
 
-            val url: String? by subscriptionSettingsModel.url.collectAsState()
-            val fileName: String? by subscriptionSettingsModel.fileName.collectAsState()
-            val urlError: String? by subscriptionSettingsModel.urlError.collectAsState()
-            val supportsAuthentication: Boolean by subscriptionSettingsModel.supportsAuthentication.collectAsState()
-            val title by subscriptionSettingsModel.title.collectAsState()
-            val color by subscriptionSettingsModel.color.collectAsState()
-            val ignoreAlerts by subscriptionSettingsModel.ignoreAlerts.collectAsState()
-            val defaultAlarmMinutes by subscriptionSettingsModel.defaultAlarmMinutes.collectAsState()
-            val defaultAllDayAlarmMinutes by subscriptionSettingsModel.defaultAllDayAlarmMinutes.collectAsState()
-            val ignoreDescription by subscriptionSettingsModel.ignoreDescription.collectAsState()
+            val url: String? by subscriptionSettingsModel.url.collectAsStateWithLifecycle()
+            val fileName: String? by subscriptionSettingsModel.fileName.collectAsStateWithLifecycle()
+            val urlError: String? by subscriptionSettingsModel.urlError.collectAsStateWithLifecycle()
+            val supportsAuthentication: Boolean by subscriptionSettingsModel.supportsAuthentication.collectAsStateWithLifecycle()
+            val title by subscriptionSettingsModel.title.collectAsStateWithLifecycle()
+            val color by subscriptionSettingsModel.color.collectAsStateWithLifecycle()
+            val ignoreAlerts by subscriptionSettingsModel.ignoreAlerts.collectAsStateWithLifecycle()
+            val defaultAlarmMinutes by subscriptionSettingsModel.defaultAlarmMinutes.collectAsStateWithLifecycle()
+            val defaultAllDayAlarmMinutes by subscriptionSettingsModel.defaultAllDayAlarmMinutes.collectAsStateWithLifecycle()
+            val ignoreDescription by subscriptionSettingsModel.ignoreDescription.collectAsStateWithLifecycle()
 
-            val requiresAuth: Boolean by credentialsModel.requiresAuth.collectAsState()
-            val username: String? by credentialsModel.username.collectAsState()
-            val password: String? by credentialsModel.password.collectAsState()
-            val isInsecure: Boolean by credentialsModel.isInsecure.collectAsState()
+            val requiresAuth: Boolean by credentialsModel.requiresAuth.collectAsStateWithLifecycle()
+            val username: String? by credentialsModel.username.collectAsStateWithLifecycle()
+            val password: String? by credentialsModel.password.collectAsStateWithLifecycle()
+            val isInsecure: Boolean by credentialsModel.isInsecure.collectAsStateWithLifecycle()
 
             val isVerifyingUrl: Boolean by validationModel.isVerifyingUrl
             val validationResult: ResourceInfo? by validationModel.result

--- a/app/src/main/java/at/bitfire/icsdroid/ui/views/AddCalendarActivity.kt
+++ b/app/src/main/java/at/bitfire/icsdroid/ui/views/AddCalendarActivity.kt
@@ -424,13 +424,6 @@ class AddCalendarActivity : AppCompatActivity() {
                 return null
             }
 
-            // Fixme: Need to push update to source flow (subscriptionSettingsModel.url) ?
-//            val supportsAuthenticate = HttpUtils.supportsAuthentication(uri)
-//            subscriptionSettingsModel.supportsAuthentication.value = supportsAuthenticate
-
-            subscriptionSettingsModel.url.value = uri.toString()
-
-
             when (uri.scheme?.lowercase()) {
                 "content" -> {
                     // SAF file, no need for auth

--- a/app/src/main/java/at/bitfire/icsdroid/ui/views/CalendarListActivity.kt
+++ b/app/src/main/java/at/bitfire/icsdroid/ui/views/CalendarListActivity.kt
@@ -59,7 +59,6 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.zIndex
 import androidx.core.content.getSystemService
 import androidx.lifecycle.AndroidViewModel
-import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.map
 import androidx.lifecycle.viewModelScope
 import androidx.work.WorkInfo
@@ -192,10 +191,10 @@ class CalendarListActivity: AppCompatActivity() {
 
         val subscriptions by model.subscriptions.observeAsState()
 
-        val askForCalendarPermission by model.askForCalendarPermission.observeAsState(false)
-        val askForNotificationPermission by model.askForNotificationPermission.observeAsState(false)
-        val askForWhitelisting by model.askForWhitelisting.observeAsState(false)
-        val askForAutoRevoke by model.askForAutoRevoke.observeAsState(false)
+        val askForCalendarPermission by model.askForCalendarPermission
+        val askForNotificationPermission by model.askForNotificationPermission
+        val askForWhitelisting by model.askForWhitelisting
+        val askForAutoRevoke by model.askForAutoRevoke
 
         Box(
             modifier = Modifier
@@ -418,12 +417,12 @@ class CalendarListActivity: AppCompatActivity() {
 
     class SubscriptionsModel(application: Application): AndroidViewModel(application) {
 
-        val askForCalendarPermission = MutableLiveData(false)
-        val askForNotificationPermission = MutableLiveData(false)
+        val askForCalendarPermission = mutableStateOf(false)
+        val askForNotificationPermission = mutableStateOf(false)
 
-        val askForWhitelisting = MutableLiveData(false)
+        val askForWhitelisting = mutableStateOf(false)
 
-        val askForAutoRevoke = MutableLiveData(false)
+        val askForAutoRevoke = mutableStateOf(false)
 
 
         /** whether there are running sync workers */
@@ -448,17 +447,17 @@ class CalendarListActivity: AppCompatActivity() {
          */
         fun checkSyncSettings() = viewModelScope.launch(Dispatchers.IO) {
             val haveNotificationPermission = PermissionUtils.haveNotificationPermission(getApplication())
-            askForNotificationPermission.postValue(!haveNotificationPermission)
+            askForNotificationPermission.value = !haveNotificationPermission
 
             val haveCalendarPermission = PermissionUtils.haveCalendarPermissions(getApplication())
-            askForCalendarPermission.postValue(!haveCalendarPermission)
+            askForCalendarPermission.value = !haveCalendarPermission
 
             val powerManager = getApplication<Application>().getSystemService<PowerManager>()
             val isIgnoringBatteryOptimizations = powerManager?.isIgnoringBatteryOptimizations(BuildConfig.APPLICATION_ID)
 
             // If not ignoring battery optimizations, and sync interval is less than a day
             val shouldWhitelistApp = isIgnoringBatteryOptimizations == false
-            askForWhitelisting.postValue(shouldWhitelistApp)
+            askForWhitelisting.value = shouldWhitelistApp
 
             // Make sure permissions are not revoked automatically
             val isAutoRevokeWhitelisted = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
@@ -466,7 +465,7 @@ class CalendarListActivity: AppCompatActivity() {
             } else {
                 true
             }
-            askForAutoRevoke.postValue(!isAutoRevokeWhitelisted)
+            askForAutoRevoke.value = !isAutoRevokeWhitelisted
         }
 
     }

--- a/app/src/main/java/at/bitfire/icsdroid/ui/views/CalendarListActivity.kt
+++ b/app/src/main/java/at/bitfire/icsdroid/ui/views/CalendarListActivity.kt
@@ -77,10 +77,10 @@ import at.bitfire.icsdroid.ui.partials.CalendarListItem
 import at.bitfire.icsdroid.ui.partials.ExtendedTopAppBar
 import at.bitfire.icsdroid.ui.partials.SyncIntervalDialog
 import at.bitfire.icsdroid.ui.theme.setContentThemed
-import java.util.ServiceLoader
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
+import java.util.ServiceLoader
 
 @OptIn(ExperimentalFoundationApi::class)
 class CalendarListActivity: AppCompatActivity() {
@@ -131,7 +131,7 @@ class CalendarListActivity: AppCompatActivity() {
 
         setContentThemed {
             compStartupServices.forEach { service ->
-                val show: Boolean by service.shouldShow().observeAsState(false)
+                val show: Boolean by service.shouldShow()
                 if (show) service.Content()
             }
 

--- a/app/src/main/java/at/bitfire/icsdroid/ui/views/EditCalendarActivity.kt
+++ b/app/src/main/java/at/bitfire/icsdroid/ui/views/EditCalendarActivity.kt
@@ -127,7 +127,7 @@ class EditCalendarActivity: AppCompatActivity() {
         }
 
         setContentThemed {
-            val successMessage by model.successMessage
+            val successMessage = model.uiState.successMessage
             // show success message
             successMessage?.let {
                 Toast.makeText(this, it, Toast.LENGTH_LONG).show()

--- a/app/src/main/java/at/bitfire/icsdroid/ui/views/EditCalendarActivity.kt
+++ b/app/src/main/java/at/bitfire/icsdroid/ui/views/EditCalendarActivity.kt
@@ -25,8 +25,8 @@ import androidx.compose.material3.IconButton
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.livedata.observeAsState
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
@@ -35,9 +35,6 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.core.app.ShareCompat
-import androidx.lifecycle.LiveData
-import androidx.lifecycle.MediatorLiveData
-import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import at.bitfire.icsdroid.R
@@ -51,6 +48,7 @@ import at.bitfire.icsdroid.ui.partials.AlertDialog
 import at.bitfire.icsdroid.ui.partials.ExtendedTopAppBar
 import at.bitfire.icsdroid.ui.partials.GenericAlertDialog
 import at.bitfire.icsdroid.ui.theme.setContentThemed
+import kotlinx.coroutines.flow.combine
 
 class EditCalendarActivity: AppCompatActivity() {
 
@@ -67,49 +65,48 @@ class EditCalendarActivity: AppCompatActivity() {
     private var initialRequiresAuthValue: Boolean? = null
 
     // Whether user made changes are legal
-    private val inputValid: LiveData<Boolean> by lazy {
-        object : MediatorLiveData<Boolean>() {
-            init {
-                addSource(subscriptionSettingsModel.title) { validate() }
-                addSource(credentialsModel.requiresAuth) { validate() }
-                addSource(credentialsModel.username) { validate() }
-                addSource(credentialsModel.password) { validate() }
+    private val inputValid by lazy {
+        combine(
+            subscriptionSettingsModel.title,
+            credentialsModel.requiresAuth,
+            credentialsModel.username,
+            credentialsModel.password
+        ) { title, requiresAuth, username, password ->
+            val titleOK = !title.isNullOrBlank()
+            val authOK = credentialsModel.run {
+                if (requiresAuth)
+                    !username.isNullOrBlank() && !password.isNullOrBlank()
+                else
+                    true
             }
-            fun validate() {
-                val titleOK = !subscriptionSettingsModel.title.value.isNullOrBlank()
-                val authOK = credentialsModel.run {
-                    if (requiresAuth.value == true)
-                        !username.value.isNullOrBlank() && !password.value.isNullOrBlank()
-                    else
-                        true
-                }
-                value = titleOK && authOK
-            }
+            titleOK && authOK
         }
     }
 
     // Whether unsaved changes exist
-    private val modelsDirty: MutableLiveData<Boolean> by lazy {
-        object : MediatorLiveData<Boolean>() {
-            init {
-                addSource(subscriptionSettingsModel.title) { value = subscriptionDirty() }
-                addSource(subscriptionSettingsModel.color) { value = subscriptionDirty() }
-                addSource(subscriptionSettingsModel.ignoreAlerts) { value = subscriptionDirty() }
-                addSource(subscriptionSettingsModel.defaultAlarmMinutes) { value = subscriptionDirty() }
-                addSource(subscriptionSettingsModel.defaultAllDayAlarmMinutes) { value = subscriptionDirty() }
-                addSource(subscriptionSettingsModel.ignoreDescription) { value = subscriptionDirty() }
-                addSource(credentialsModel.requiresAuth) { value = credentialDirty() }
-                addSource(credentialsModel.username) { value = credentialDirty() }
-                addSource(credentialsModel.password) { value = credentialDirty() }
-            }
-            fun subscriptionDirty() = initialSubscription?.let {
-                !subscriptionSettingsModel.equalsSubscription(it)
-            } ?: false
-            fun credentialDirty() =
-                initialRequiresAuthValue != credentialsModel.requiresAuth.value ||
-                initialCredential?.let {
-                    !credentialsModel.equalsCredential(it)
+    private val modelsDirty by lazy {
+        combine(
+            combine(
+                credentialsModel.requiresAuth,
+                credentialsModel.username,
+                credentialsModel.password
+            ) { requiresAuth, _, _ ->
+                initialRequiresAuthValue != requiresAuth ||
+                        initialCredential?.let { !credentialsModel.equalsCredential(it) } ?: false
+            },
+            combine(
+                subscriptionSettingsModel.title,
+                subscriptionSettingsModel.color,
+                subscriptionSettingsModel.ignoreAlerts,
+                subscriptionSettingsModel.defaultAlarmMinutes,
+                subscriptionSettingsModel.defaultAllDayAlarmMinutes,
+                subscriptionSettingsModel.ignoreDescription
+            ) {
+                initialSubscription?.let {
+                    !subscriptionSettingsModel.equalsSubscription(it)
                 } ?: false
+            }) { credentialsDirty, subscriptionsDirty ->
+            credentialsDirty || subscriptionsDirty
         }
     }
 
@@ -170,16 +167,16 @@ class EditCalendarActivity: AppCompatActivity() {
             subscriptionSettingsModel.color.value = it
         }
         subscription.ignoreEmbeddedAlerts.let {
-            subscriptionSettingsModel.ignoreAlerts.postValue(it)
+            subscriptionSettingsModel.ignoreAlerts.value = it
         }
         subscription.defaultAlarmMinutes.let {
-            subscriptionSettingsModel.defaultAlarmMinutes.postValue(it)
+            subscriptionSettingsModel.defaultAlarmMinutes.value = it
         }
         subscription.defaultAllDayAlarmMinutes.let {
-            subscriptionSettingsModel.defaultAllDayAlarmMinutes.postValue(it)
+            subscriptionSettingsModel.defaultAllDayAlarmMinutes.value = it
         }
         subscription.ignoreDescription.let {
-            subscriptionSettingsModel.ignoreDescription.postValue(it)
+            subscriptionSettingsModel.ignoreDescription.value = it
         }
 
         val credential = subscriptionWithCredential.credential
@@ -221,15 +218,15 @@ class EditCalendarActivity: AppCompatActivity() {
 
     @Composable
     private fun EditCalendarComposable() {
-        val url by subscriptionSettingsModel.url.observeAsState("")
-        val title by subscriptionSettingsModel.title.observeAsState("")
-        val color by subscriptionSettingsModel.color.observeAsState()
-        val ignoreAlerts by subscriptionSettingsModel.ignoreAlerts.observeAsState(false)
-        val defaultAlarmMinutes by subscriptionSettingsModel.defaultAlarmMinutes.observeAsState()
-        val defaultAllDayAlarmMinutes by subscriptionSettingsModel.defaultAllDayAlarmMinutes.observeAsState()
-        val ignoreDescription by subscriptionSettingsModel.ignoreDescription.observeAsState(false)
-        val inputValid by inputValid.observeAsState(false)
-        val modelsDirty by modelsDirty.observeAsState(false)
+        val url by subscriptionSettingsModel.url.collectAsState()
+        val title by subscriptionSettingsModel.title.collectAsState()
+        val color by subscriptionSettingsModel.color.collectAsState()
+        val ignoreAlerts by subscriptionSettingsModel.ignoreAlerts.collectAsState()
+        val defaultAlarmMinutes by subscriptionSettingsModel.defaultAlarmMinutes.collectAsState()
+        val defaultAllDayAlarmMinutes by subscriptionSettingsModel.defaultAllDayAlarmMinutes.collectAsState()
+        val ignoreDescription by subscriptionSettingsModel.ignoreDescription.collectAsState()
+        val inputValid by inputValid.collectAsState(false)
+        val modelsDirty by modelsDirty.collectAsState(false)
         Scaffold(
             topBar = { AppBarComposable(inputValid, modelsDirty) }
         ) { paddingValues ->
@@ -242,42 +239,38 @@ class EditCalendarActivity: AppCompatActivity() {
                 SubscriptionSettingsComposable(
                     url = url,
                     title = title,
-                    titleChanged = { subscriptionSettingsModel.title.postValue(it) },
+                    titleChanged = { subscriptionSettingsModel.title.value = it },
                     color = color,
-                    colorChanged = subscriptionSettingsModel.color::postValue,
+                    colorChanged = { subscriptionSettingsModel.color.value = it },
                     ignoreAlerts = ignoreAlerts,
-                    ignoreAlertsChanged = { subscriptionSettingsModel.ignoreAlerts.postValue(it) },
+                    ignoreAlertsChanged = { subscriptionSettingsModel.ignoreAlerts.value = it },
                     defaultAlarmMinutes = defaultAlarmMinutes,
                     defaultAlarmMinutesChanged = {
-                        subscriptionSettingsModel.defaultAlarmMinutes.postValue(
-                            it.toLongOrNull()
-                        )
+                        subscriptionSettingsModel.defaultAlarmMinutes.value = it.toLongOrNull()
                     },
                     defaultAllDayAlarmMinutes = defaultAllDayAlarmMinutes,
                     defaultAllDayAlarmMinutesChanged = {
-                        subscriptionSettingsModel.defaultAllDayAlarmMinutes.postValue(
-                            it.toLongOrNull()
-                        )
+                        subscriptionSettingsModel.defaultAllDayAlarmMinutes.value = it.toLongOrNull()
                     },
                     ignoreDescription = ignoreDescription,
-                    onIgnoreDescriptionChanged = subscriptionSettingsModel.ignoreDescription::postValue,
+                    onIgnoreDescriptionChanged = {
+                        subscriptionSettingsModel.ignoreDescription.value = it
+                    },
                     isCreating = false,
                     modifier = Modifier.fillMaxWidth()
                 )
-                val supportsAuthentication: Boolean by subscriptionSettingsModel.supportsAuthentication.observeAsState(
-                    false
-                )
-                val requiresAuth: Boolean by credentialsModel.requiresAuth.observeAsState(false)
-                val username: String? by credentialsModel.username.observeAsState(null)
-                val password: String? by credentialsModel.password.observeAsState(null)
+                val supportsAuthentication by subscriptionSettingsModel.supportsAuthentication.collectAsState(false)
+                val requiresAuth: Boolean by credentialsModel.requiresAuth.collectAsState(false)
+                val username: String? by credentialsModel.username.collectAsState(null)
+                val password: String? by credentialsModel.password.collectAsState(null)
                 AnimatedVisibility(visible = supportsAuthentication) {
                     LoginCredentialsComposable(
                         requiresAuth,
                         username,
                         password,
-                        onRequiresAuthChange = credentialsModel.requiresAuth::setValue,
-                        onUsernameChange = credentialsModel.username::setValue,
-                        onPasswordChange = credentialsModel.password::setValue
+                        onRequiresAuthChange = { credentialsModel.requiresAuth.value = it },
+                        onUsernameChange = { credentialsModel.username.value = it },
+                        onPasswordChange = { credentialsModel.password.value = it }
                     )
                 }
             }

--- a/app/src/main/java/at/bitfire/icsdroid/ui/views/EditCalendarActivity.kt
+++ b/app/src/main/java/at/bitfire/icsdroid/ui/views/EditCalendarActivity.kt
@@ -129,15 +129,13 @@ class EditCalendarActivity: AppCompatActivity() {
                 onSubscriptionLoaded(data)
         }
 
-        // handle status changes
-        model.successMessage.observe(this) { message ->
-            if (message != null) {
-                Toast.makeText(this, message, Toast.LENGTH_LONG).show()
+        setContentThemed {
+            val successMessage by model.successMessage
+            // show success message
+            successMessage?.let {
+                Toast.makeText(this, it, Toast.LENGTH_LONG).show()
                 finish()
             }
-        }
-
-        setContentThemed {
             // show error message from calling intent, if available
             var showingErrorMessage by remember {
                 mutableStateOf(inState == null && intent.hasExtra(EXTRA_ERROR_MESSAGE))

--- a/app/src/main/java/at/bitfire/icsdroid/ui/views/EditCalendarActivity.kt
+++ b/app/src/main/java/at/bitfire/icsdroid/ui/views/EditCalendarActivity.kt
@@ -25,7 +25,6 @@ import androidx.compose.material3.IconButton
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -37,6 +36,7 @@ import androidx.compose.ui.unit.dp
 import androidx.core.app.ShareCompat
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import at.bitfire.icsdroid.R
 import at.bitfire.icsdroid.db.dao.SubscriptionsDao
 import at.bitfire.icsdroid.db.entity.Credential
@@ -216,15 +216,15 @@ class EditCalendarActivity: AppCompatActivity() {
 
     @Composable
     private fun EditCalendarComposable() {
-        val url by subscriptionSettingsModel.url.collectAsState()
-        val title by subscriptionSettingsModel.title.collectAsState()
-        val color by subscriptionSettingsModel.color.collectAsState()
-        val ignoreAlerts by subscriptionSettingsModel.ignoreAlerts.collectAsState()
-        val defaultAlarmMinutes by subscriptionSettingsModel.defaultAlarmMinutes.collectAsState()
-        val defaultAllDayAlarmMinutes by subscriptionSettingsModel.defaultAllDayAlarmMinutes.collectAsState()
-        val ignoreDescription by subscriptionSettingsModel.ignoreDescription.collectAsState()
-        val inputValid by inputValid.collectAsState(false)
-        val modelsDirty by modelsDirty.collectAsState(false)
+        val url by subscriptionSettingsModel.url.collectAsStateWithLifecycle()
+        val title by subscriptionSettingsModel.title.collectAsStateWithLifecycle()
+        val color by subscriptionSettingsModel.color.collectAsStateWithLifecycle()
+        val ignoreAlerts by subscriptionSettingsModel.ignoreAlerts.collectAsStateWithLifecycle()
+        val defaultAlarmMinutes by subscriptionSettingsModel.defaultAlarmMinutes.collectAsStateWithLifecycle()
+        val defaultAllDayAlarmMinutes by subscriptionSettingsModel.defaultAllDayAlarmMinutes.collectAsStateWithLifecycle()
+        val ignoreDescription by subscriptionSettingsModel.ignoreDescription.collectAsStateWithLifecycle()
+        val inputValid by inputValid.collectAsStateWithLifecycle(false)
+        val modelsDirty by modelsDirty.collectAsStateWithLifecycle(false)
         Scaffold(
             topBar = { AppBarComposable(inputValid, modelsDirty) }
         ) { paddingValues ->
@@ -257,10 +257,10 @@ class EditCalendarActivity: AppCompatActivity() {
                     isCreating = false,
                     modifier = Modifier.fillMaxWidth()
                 )
-                val supportsAuthentication by subscriptionSettingsModel.supportsAuthentication.collectAsState(false)
-                val requiresAuth: Boolean by credentialsModel.requiresAuth.collectAsState(false)
-                val username: String? by credentialsModel.username.collectAsState(null)
-                val password: String? by credentialsModel.password.collectAsState(null)
+                val supportsAuthentication by subscriptionSettingsModel.supportsAuthentication.collectAsStateWithLifecycle()
+                val requiresAuth: Boolean by credentialsModel.requiresAuth.collectAsStateWithLifecycle()
+                val username: String? by credentialsModel.username.collectAsStateWithLifecycle()
+                val password: String? by credentialsModel.password.collectAsStateWithLifecycle()
                 AnimatedVisibility(visible = supportsAuthentication) {
                     LoginCredentialsComposable(
                         requiresAuth,

--- a/app/src/standard/java/at/bitfire/icsdroid/ui/DonateDialogService.kt
+++ b/app/src/standard/java/at/bitfire/icsdroid/ui/DonateDialogService.kt
@@ -10,12 +10,12 @@ import androidx.appcompat.app.AppCompatActivity
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.State
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.res.stringResource
-import androidx.lifecycle.LiveData
-import androidx.lifecycle.MutableLiveData
 import at.bitfire.icsdroid.R
 import at.bitfire.icsdroid.service.ComposableStartupService
 import at.bitfire.icsdroid.ui.partials.GenericAlertDialog
@@ -69,7 +69,7 @@ class DonateDialogService: ComposableStartupService {
      * *true* if the preference value lies in the past, or *false* otherwise.
      */
     @Composable
-    override fun shouldShow(): LiveData<Boolean> = remember { MutableLiveData(false) }.also {
+    override fun shouldShow(): State<Boolean> = remember { mutableStateOf(false) }.also {
         val activity = getActivity() ?: return@also
         DisposableEffect(it) {
             val listener = OnSharedPreferenceChangeListener { sharedPreferences, key ->
@@ -77,7 +77,7 @@ class DonateDialogService: ComposableStartupService {
                 if (key != PREF_NEXT_REMINDER) return@OnSharedPreferenceChangeListener
                 // Get preference value, calculate livedata value and post it
                 val nextReminderTime = sharedPreferences.getLong(PREF_NEXT_REMINDER, 0)
-                it.postValue(nextReminderTime < System.currentTimeMillis())
+                it.value = nextReminderTime < System.currentTimeMillis()
             }
             val preferences = getPreferences(activity)
             preferences.registerOnSharedPreferenceChangeListener(listener)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -38,6 +38,7 @@ androidx-appCompat = { module = "androidx.appcompat:appcompat", version.ref = "a
 androidx-arch-core-testing = { module = "androidx.arch.core:core-testing", version.ref = "androidx-archCore" }
 androidx-core = { module = "androidx.core:core-ktx", version.ref = "androidx-core" }
 androidx-lifecycle-viewmodel = { module = "androidx.lifecycle:lifecycle-viewmodel-ktx", version.ref = "androidx-lifecycle" }
+androidx-lifecycle-runtime-compose = { module = "androidx.lifecycle:lifecycle-runtime-compose", version.ref = "androidx-lifecycle" }
 androidx-test-rules = { module = "androidx.test:rules", version.ref = "androidx-test-rules" }
 androidx-test-runner = { module = "androidx.test:runner", version.ref = "androidx-test-runner" }
 androidx-work-runtime = { module = "androidx.work:work-runtime-ktx", version.ref = "androidx-work" }


### PR DESCRIPTION
### Purpose

Replacing LiveData with compose state and flows, will in the future hopefully prevent the issues that came with LiveData. Also it makes for easier integration with DAVx5.

### Short description

This is the **2. Iteration** of the switch from LiveData to compose state and kotlin flows. See the [1. iteration here](https://github.com/bitfireAT/icsx5/pull/279).

The 1. Iteration took care of the Database Access Objects. It deprecated LiveData returning methods and added their respective Flow returning variants.

In this 2. iteration models and activities are rewritten, by replacing all LiveData usages in both models and activities,  **excluding**  any 1. iteration DAO changes, since this PR would grow too big otherwise.

The 3. iteration will take care of using the new Flow returning methods in DAOs and remove the last remaining LiveData usages.

This PR:
- Prefers compose state over StateFlows where possible
- Uses StateFlow in `CredentialsModel` and `SubscriptionSettingsModel` since their flow type members are merged in `EditCalendarActivity` and it is not possible to merge compose states, to my knowledge. In any case, the declaration of `modelsDirty` needs special attention.
- introduces `uiState` data classes with private set where possible 

### Checklist

- [X] The PR has a proper title, description and label.
- [x] I have [self-reviewed the PR](https://patrickdinh.medium.com/review-your-own-pull-requests-5634cad10b7a).
- [X] I have added documentation to complex functions and functions that can be used by other modules.
- [X] I have added reasonable tests or consciously decided to not add tests.
