### PR TITLE
[Severe] Editing/Deleting subscriptions doesn't update the UI

### DIFF
--- a/app/src/main/java/at/bitfire/icsdroid/ui/views/EditCalendarActivity.kt
+++ b/app/src/main/java/at/bitfire/icsdroid/ui/views/EditCalendarActivity.kt
@@ -25,6 +25,7 @@ import androidx.compose.material3.IconButton
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -133,9 +134,7 @@ class EditCalendarActivity: AppCompatActivity() {
                 Toast.makeText(this, it, Toast.LENGTH_LONG).show()
                 finish()
             }
-        }
 
-        setContentThemed {
             EditCalendarComposable()
         }
     }


### PR DESCRIPTION
We were calling `setContent` twice, so the first one (which had the state receiver) was not being called.