### PR TITLE
EditCalendarActvivity: Switch to compose state and kotlin flows

### DIFF
--- a/app/src/main/java/at/bitfire/icsdroid/model/EditCalendarModel.kt
+++ b/app/src/main/java/at/bitfire/icsdroid/model/EditCalendarModel.kt
@@ -62,7 +62,7 @@ class EditCalendarModel(
     /**
      * Initialise view models and remember their initial state
      */
-    fun onSubscriptionLoaded(subscriptionWithCredential: SubscriptionsDao.SubscriptionWithCredential) {
+    private fun onSubscriptionLoaded(subscriptionWithCredential: SubscriptionsDao.SubscriptionWithCredential) {
         val subscription = subscriptionWithCredential.subscription
 
         subscriptionSettingsModel.setUrl(subscription.url.toString())
@@ -90,7 +90,4 @@ class EditCalendarModel(
         initialRequiresAuthValue = credentialsModel.uiState.requiresAuth
     }
 
-    fun onSave() = editSubscriptionModel.updateSubscription(subscriptionSettingsModel, credentialsModel)
-
-    fun onDelete() = editSubscriptionModel.removeSubscription()
 }

--- a/app/src/main/java/at/bitfire/icsdroid/model/EditCalendarModel.kt
+++ b/app/src/main/java/at/bitfire/icsdroid/model/EditCalendarModel.kt
@@ -1,0 +1,96 @@
+package at.bitfire.icsdroid.model
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import at.bitfire.icsdroid.db.dao.SubscriptionsDao
+import at.bitfire.icsdroid.db.entity.Credential
+import at.bitfire.icsdroid.db.entity.Subscription
+import kotlinx.coroutines.launch
+
+class EditCalendarModel(
+    val editSubscriptionModel: EditSubscriptionModel,
+    val subscriptionSettingsModel: SubscriptionSettingsModel,
+    val credentialsModel: CredentialsModel
+): ViewModel() {
+
+    private var initialSubscription: Subscription? = null
+    private var initialCredential: Credential? = null
+    private var initialRequiresAuthValue: Boolean? = null
+
+    init {
+        // Initialise view models and save their initial state
+        viewModelScope.launch {
+            editSubscriptionModel.subscriptionWithCredential.collect { data ->
+                if (data != null)
+                    onSubscriptionLoaded(data)
+            }
+        }
+    }
+
+    val inputValid: Boolean
+        @Composable
+        get() = remember(subscriptionSettingsModel.uiState, credentialsModel.uiState) {
+            val title = subscriptionSettingsModel.uiState.title
+            val requiresAuth = credentialsModel.uiState.requiresAuth
+            val username = credentialsModel.uiState.username
+            val password = credentialsModel.uiState.password
+
+            val titleOK = !title.isNullOrBlank()
+            val authOK = if (requiresAuth)
+                !username.isNullOrBlank() && !password.isNullOrBlank()
+            else
+                true
+            titleOK && authOK
+        }
+
+    val modelsDirty: Boolean
+        @Composable
+        get() = remember(subscriptionSettingsModel.uiState, credentialsModel.uiState) {
+            val requiresAuth = credentialsModel.uiState.requiresAuth
+
+            val credentialsDirty = initialRequiresAuthValue != requiresAuth ||
+                    initialCredential?.let { !credentialsModel.equalsCredential(it) } ?: false
+            val subscriptionsDirty = initialSubscription?.let {
+                !subscriptionSettingsModel.equalsSubscription(it)
+            } ?: false
+
+            credentialsDirty || subscriptionsDirty
+        }
+
+    /**
+     * Initialise view models and remember their initial state
+     */
+    fun onSubscriptionLoaded(subscriptionWithCredential: SubscriptionsDao.SubscriptionWithCredential) {
+        val subscription = subscriptionWithCredential.subscription
+
+        subscriptionSettingsModel.setUrl(subscription.url.toString())
+        subscription.displayName.let {
+            subscriptionSettingsModel.setTitle(it)
+        }
+        subscription.color.let(subscriptionSettingsModel::setColor)
+        subscription.ignoreEmbeddedAlerts.let(subscriptionSettingsModel::setIgnoreAlerts)
+        subscription.defaultAlarmMinutes?.toString().let(subscriptionSettingsModel::setDefaultAlarmMinutes)
+        subscription.defaultAllDayAlarmMinutes?.toString()?.let(subscriptionSettingsModel::setDefaultAllDayAlarmMinutes)
+        subscription.ignoreDescription.let(subscriptionSettingsModel::setIgnoreDescription)
+
+        val credential = subscriptionWithCredential.credential
+        val requiresAuth = credential != null
+        credentialsModel.setRequiresAuth(requiresAuth)
+
+        if (credential != null) {
+            credential.username.let(credentialsModel::setUsername)
+            credential.password.let(credentialsModel::setPassword)
+        }
+
+        // Save state, before user makes changes
+        initialSubscription = subscription
+        initialCredential = credential
+        initialRequiresAuthValue = credentialsModel.uiState.requiresAuth
+    }
+
+    fun onSave() = editSubscriptionModel.updateSubscription(subscriptionSettingsModel, credentialsModel)
+
+    fun onDelete() = editSubscriptionModel.removeSubscription()
+}

--- a/app/src/main/java/at/bitfire/icsdroid/model/EditCalendarModel.kt
+++ b/app/src/main/java/at/bitfire/icsdroid/model/EditCalendarModel.kt
@@ -29,6 +29,9 @@ class EditCalendarModel(
         }
     }
 
+    /**
+     * Whether user input is error free
+     */
     val inputValid: Boolean
         @Composable
         get() = remember(subscriptionSettingsModel.uiState, credentialsModel.uiState) {
@@ -45,6 +48,9 @@ class EditCalendarModel(
             titleOK && authOK
         }
 
+    /**
+     * Whether there are unsaved user changes
+     */
     val modelsDirty: Boolean
         @Composable
         get() = remember(subscriptionSettingsModel.uiState, credentialsModel.uiState) {

--- a/app/src/main/java/at/bitfire/icsdroid/ui/screen/EditCalendarScreen.kt
+++ b/app/src/main/java/at/bitfire/icsdroid/ui/screen/EditCalendarScreen.kt
@@ -94,9 +94,9 @@ private fun EditCalendarScreen(
                 .padding(16.dp)
         ) {
             SubscriptionSettingsComposable(
+                modifier = Modifier.fillMaxWidth(),
                 subscriptionSettingsModel,
-                isCreating = false,
-                modifier = Modifier.fillMaxWidth()
+                isCreating = false
             )
             AnimatedVisibility(visible = supportsAuthentication) {
                 LoginCredentialsComposable(

--- a/app/src/main/java/at/bitfire/icsdroid/ui/screen/EditCalendarScreen.kt
+++ b/app/src/main/java/at/bitfire/icsdroid/ui/screen/EditCalendarScreen.kt
@@ -1,5 +1,6 @@
 package at.bitfire.icsdroid.ui.screen
 
+import android.widget.Toast
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -22,6 +23,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -40,6 +42,11 @@ fun EditCalendarScreen(
     onShare: () -> Unit,
     onExit: () -> Unit
 ) {
+    // show success message
+    editCalendarModel.editSubscriptionModel.uiState.successMessage?.let { successMessage ->
+        Toast.makeText(LocalContext.current, successMessage, Toast.LENGTH_LONG).show()
+        onExit()
+    }
     Scaffold(
         topBar = { AppBarComposable(
             editCalendarModel.inputValid,

--- a/app/src/main/java/at/bitfire/icsdroid/ui/screen/EditCalendarScreen.kt
+++ b/app/src/main/java/at/bitfire/icsdroid/ui/screen/EditCalendarScreen.kt
@@ -64,15 +64,15 @@ fun EditCalendarScreen(
         onSave = {
             editSubscriptionModel.updateSubscription(subscriptionSettingsModel, credentialsModel)
         },
-        {
+        onShare = {
             editSubscriptionModel.subscriptionWithCredential.value?.let {
                 onShare(it.subscription)
             }
         },
-        onExit,
-        editCalendarModel.subscriptionSettingsModel.uiState.supportsAuthentication,
-        editCalendarModel.subscriptionSettingsModel,
-        editCalendarModel.credentialsModel
+        onExit = onExit,
+        supportsAuthentication = editCalendarModel.subscriptionSettingsModel.uiState.supportsAuthentication,
+        subscriptionSettingsModel = editCalendarModel.subscriptionSettingsModel,
+        credentialsModel = editCalendarModel.credentialsModel
     )
 }
 @Composable
@@ -97,12 +97,12 @@ fun EditCalendarScreen(
     Scaffold(
         topBar = {
             AppBarComposable(
-                inputValid,
-                modelsDirty,
-                onDelete,
-                onSave,
-                onShare,
-                onExit
+                valid = inputValid,
+                modelsDirty = modelsDirty,
+                onDelete = onDelete,
+                onSave = onSave,
+                onShare = onShare,
+                onExit = onExit
             )
         }
     ) { paddingValues ->

--- a/app/src/main/java/at/bitfire/icsdroid/ui/screen/EditCalendarScreen.kt
+++ b/app/src/main/java/at/bitfire/icsdroid/ui/screen/EditCalendarScreen.kt
@@ -25,6 +25,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.lifecycle.viewmodel.compose.viewModel
 import at.bitfire.icsdroid.R
 import at.bitfire.icsdroid.model.CredentialsModel
 import at.bitfire.icsdroid.model.SubscriptionSettingsModel
@@ -46,29 +47,10 @@ fun EditCalendarScreen(
     onExit: () -> Unit
 ) {
     EditCalendarScreen(
-        credentialsModel.uiState.username,
-        credentialsModel.uiState.password,
-        credentialsModel.uiState.requiresAuth,
-
-        credentialsModel::setRequiresAuth,
-        credentialsModel::setUsername,
-        credentialsModel::setPassword,
-
+        subscriptionSettingsModel,
         subscriptionSettingsModel.uiState.supportsAuthentication,
-        subscriptionSettingsModel.uiState.url,
-        subscriptionSettingsModel.uiState.title,
-        subscriptionSettingsModel.uiState.color,
-        subscriptionSettingsModel.uiState.ignoreAlerts,
-        subscriptionSettingsModel.uiState.defaultAlarmMinutes,
-        subscriptionSettingsModel.uiState.defaultAllDayAlarmMinutes,
-        subscriptionSettingsModel.uiState.ignoreDescription,
 
-        subscriptionSettingsModel::setTitle,
-        subscriptionSettingsModel::setColor,
-        subscriptionSettingsModel::setIgnoreAlerts,
-        subscriptionSettingsModel::setDefaultAlarmMinutes,
-        subscriptionSettingsModel::setDefaultAllDayAlarmMinutes,
-        subscriptionSettingsModel::setIgnoreDescription,
+        credentialsModel,
 
         inputValid,
         modelsDirty,
@@ -82,29 +64,10 @@ fun EditCalendarScreen(
 
 @Composable
 private fun EditCalendarScreen(
-    username: String?,
-    password: String?,
-    requiresAuth: Boolean,
-
-    setRequiresAuth: (Boolean) -> Unit,
-    setUsername: (String) -> Unit,
-    setPassword: (String) -> Unit,
-
+    subscriptionSettingsModel: SubscriptionSettingsModel,
     supportsAuthentication: Boolean,
-    url: String?,
-    title: String?,
-    color: Int?,
-    ignoreAlerts: Boolean,
-    defaultAlarmMinutes: Long?,
-    defaultAllDayAlarmMinutes: Long?,
-    ignoreDescription: Boolean,
 
-    setTitle: (String) -> Unit,
-    setColor: (Int) -> Unit,
-    setIgnoreAlerts: (Boolean) -> Unit,
-    setDefaultAlarmMinutes: (String) -> Unit,
-    setDefaultAllDayAlarmMinutes: (String) -> Unit,
-    setIgnoreDescription: (Boolean) -> Unit,
+    credentialsModel: CredentialsModel,
 
     inputValid: Boolean,
     modelsDirty: Boolean,
@@ -131,30 +94,13 @@ private fun EditCalendarScreen(
                 .padding(16.dp)
         ) {
             SubscriptionSettingsComposable(
-                url = url,
-                title = title,
-                titleChanged = setTitle,
-                color = color,
-                colorChanged = setColor,
-                ignoreAlerts = ignoreAlerts,
-                ignoreAlertsChanged = setIgnoreAlerts,
-                defaultAlarmMinutes = defaultAlarmMinutes,
-                defaultAlarmMinutesChanged = setDefaultAlarmMinutes,
-                defaultAllDayAlarmMinutes = defaultAllDayAlarmMinutes,
-                defaultAllDayAlarmMinutesChanged = setDefaultAllDayAlarmMinutes,
-                ignoreDescription = ignoreDescription,
-                onIgnoreDescriptionChanged = setIgnoreDescription,
+                subscriptionSettingsModel,
                 isCreating = false,
                 modifier = Modifier.fillMaxWidth()
             )
             AnimatedVisibility(visible = supportsAuthentication) {
                 LoginCredentialsComposable(
-                    requiresAuth,
-                    username,
-                    password,
-                    onRequiresAuthChange = setRequiresAuth,
-                    onUsernameChange = setUsername,
-                    onPasswordChange = setPassword
+                    credentialsModel
                 )
             }
         }
@@ -238,27 +184,10 @@ private fun AppBarComposable(
 fun EditCalendarScreen_Preview() {
     AppTheme {
         EditCalendarScreen(
-            username = "username",
-            password = "password",
-            requiresAuth = true,
-            setRequiresAuth = {},
-            setUsername = {},
-            setPassword = {},
-
+            subscriptionSettingsModel = viewModel(),
             supportsAuthentication = true,
-            url = "url",
-            title = "title",
-            color = 0,
-            ignoreAlerts = true,
-            defaultAlarmMinutes = 5L,
-            defaultAllDayAlarmMinutes = 10L,
-            ignoreDescription = false,
-            setTitle = {},
-            setColor = {},
-            setIgnoreAlerts = {},
-            setDefaultAlarmMinutes = {},
-            setDefaultAllDayAlarmMinutes = {},
-            setIgnoreDescription = {},
+
+            credentialsModel = viewModel(),
 
             inputValid = true,
             modelsDirty = true,

--- a/app/src/main/java/at/bitfire/icsdroid/ui/screen/EditCalendarScreen.kt
+++ b/app/src/main/java/at/bitfire/icsdroid/ui/screen/EditCalendarScreen.kt
@@ -71,8 +71,30 @@ fun EditCalendarScreen(
         },
         onExit = onExit,
         supportsAuthentication = editCalendarModel.subscriptionSettingsModel.uiState.supportsAuthentication,
-        subscriptionSettingsModel = editCalendarModel.subscriptionSettingsModel,
-        credentialsModel = editCalendarModel.credentialsModel
+
+        // Subscription settings model
+        url = subscriptionSettingsModel.uiState.url,
+        title = subscriptionSettingsModel.uiState.title,
+        titleChanged = subscriptionSettingsModel::setTitle,
+        color = subscriptionSettingsModel.uiState.color,
+        colorChanged = subscriptionSettingsModel::setColor,
+        ignoreAlerts = subscriptionSettingsModel.uiState.ignoreAlerts,
+        ignoreAlertsChanged = subscriptionSettingsModel::setIgnoreAlerts,
+        defaultAlarmMinutes = subscriptionSettingsModel.uiState.defaultAlarmMinutes,
+        defaultAlarmMinutesChanged = subscriptionSettingsModel::setDefaultAlarmMinutes,
+        defaultAllDayAlarmMinutes = subscriptionSettingsModel.uiState.defaultAllDayAlarmMinutes,
+        defaultAllDayAlarmMinutesChanged = subscriptionSettingsModel::setDefaultAllDayAlarmMinutes,
+        ignoreDescription = subscriptionSettingsModel.uiState.ignoreDescription,
+        onIgnoreDescriptionChanged = subscriptionSettingsModel::setIgnoreDescription,
+        isCreating = false,
+
+        // Credentials model
+        requiresAuth = credentialsModel.uiState.requiresAuth,
+        username = credentialsModel.uiState.username,
+        password = credentialsModel.uiState.password,
+        onRequiresAuthChange = credentialsModel::setRequiresAuth,
+        onUsernameChange = credentialsModel::setUsername,
+        onPasswordChange = credentialsModel::setPassword,
     )
 }
 @Composable
@@ -85,8 +107,30 @@ fun EditCalendarScreen(
     onShare: () -> Unit,
     onExit: () -> Unit,
     supportsAuthentication: Boolean,
-    subscriptionSettingsModel: SubscriptionSettingsModel,
-    credentialsModel: CredentialsModel
+
+    // Subscription settings model
+    url: String?,
+    title: String?,
+    titleChanged: (String) -> Unit,
+    color: Int?,
+    colorChanged: (Int) -> Unit,
+    ignoreAlerts: Boolean,
+    ignoreAlertsChanged: (Boolean) -> Unit,
+    defaultAlarmMinutes: Long?,
+    defaultAlarmMinutesChanged: (String) -> Unit,
+    defaultAllDayAlarmMinutes: Long?,
+    defaultAllDayAlarmMinutesChanged: (String) -> Unit,
+    ignoreDescription: Boolean,
+    onIgnoreDescriptionChanged: (Boolean) -> Unit,
+    isCreating: Boolean,
+
+    // Credentials model
+    requiresAuth: Boolean,
+    username: String? = null,
+    password: String? = null,
+    onRequiresAuthChange: (Boolean) -> Unit,
+    onUsernameChange: (String) -> Unit,
+    onPasswordChange: (String) -> Unit
 ) {
     // show success message
     successMessage?.let {
@@ -114,14 +158,31 @@ fun EditCalendarScreen(
         ) {
             SubscriptionSettingsComposable(
                 modifier = Modifier.fillMaxWidth(),
-                subscriptionSettingsModel,
-                isCreating = false
+                url = url,
+                title = title,
+                titleChanged = titleChanged,
+                color = color,
+                colorChanged = colorChanged,
+                ignoreAlerts = ignoreAlerts,
+                ignoreAlertsChanged = ignoreAlertsChanged,
+                defaultAlarmMinutes = defaultAlarmMinutes,
+                defaultAlarmMinutesChanged = defaultAlarmMinutesChanged,
+                defaultAllDayAlarmMinutes = defaultAllDayAlarmMinutes,
+                defaultAllDayAlarmMinutesChanged = defaultAllDayAlarmMinutesChanged,
+                ignoreDescription = ignoreDescription,
+                onIgnoreDescriptionChanged = onIgnoreDescriptionChanged,
+                isCreating = isCreating
             )
             AnimatedVisibility(
                 visible = supportsAuthentication
             ) {
                 LoginCredentialsComposable(
-                    credentialsModel
+                    requiresAuth = requiresAuth,
+                    username = username,
+                    password = password,
+                    onRequiresAuthChange = onRequiresAuthChange,
+                    onUsernameChange = onUsernameChange,
+                    onPasswordChange = onPasswordChange
                 )
             }
         }
@@ -213,8 +274,30 @@ fun EditCalendarScreen_Preview() {
             onShare = {},
             onExit = {},
             supportsAuthentication = true,
-            subscriptionSettingsModel = viewModel(),
-            credentialsModel = viewModel()
+
+            // Subscription settings model
+            url = "url",
+            title = "title",
+            titleChanged = {},
+            color = 0,
+            colorChanged = {},
+            ignoreAlerts = true,
+            ignoreAlertsChanged = {},
+            defaultAlarmMinutes = 20L,
+            defaultAlarmMinutesChanged = {},
+            defaultAllDayAlarmMinutes = 10L,
+            defaultAllDayAlarmMinutesChanged = {},
+            ignoreDescription = false,
+            onIgnoreDescriptionChanged = {},
+            isCreating = true,
+
+            // Credentials model
+            requiresAuth = true,
+            username = "",
+            password = "",
+            onRequiresAuthChange = {},
+            onUsernameChange = {},
+            onPasswordChange = {}
         )
     }
 }

--- a/app/src/main/java/at/bitfire/icsdroid/ui/screen/EditCalendarScreen.kt
+++ b/app/src/main/java/at/bitfire/icsdroid/ui/screen/EditCalendarScreen.kt
@@ -1,5 +1,6 @@
 package at.bitfire.icsdroid.ui.screen
 
+import android.app.Application
 import android.widget.Toast
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.foundation.layout.Column
@@ -25,23 +26,35 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import at.bitfire.icsdroid.R
+import at.bitfire.icsdroid.db.entity.Subscription
+import at.bitfire.icsdroid.model.CredentialsModel
 import at.bitfire.icsdroid.model.EditCalendarModel
+import at.bitfire.icsdroid.model.EditSubscriptionModel
+import at.bitfire.icsdroid.model.SubscriptionSettingsModel
 import at.bitfire.icsdroid.ui.partials.ExtendedTopAppBar
 import at.bitfire.icsdroid.ui.partials.GenericAlertDialog
-import at.bitfire.icsdroid.ui.theme.AppTheme
 import at.bitfire.icsdroid.ui.views.LoginCredentialsComposable
 import at.bitfire.icsdroid.ui.views.SubscriptionSettingsComposable
 
 @Composable
 fun EditCalendarScreen(
-    editCalendarModel: EditCalendarModel = viewModel(),
-    onShare: () -> Unit,
+    application: Application,
+    subscriptionId: Long,
+    onShare: (subscription: Subscription) -> Unit,
     onExit: () -> Unit
 ) {
+    val credentialsModel: CredentialsModel = viewModel()
+    val subscriptionSettingsModel: SubscriptionSettingsModel = viewModel()
+    val editSubscriptionModel: EditSubscriptionModel = viewModel {
+        EditSubscriptionModel(application, subscriptionId)
+    }
+    val editCalendarModel: EditCalendarModel = viewModel {
+        EditCalendarModel(editSubscriptionModel, subscriptionSettingsModel, credentialsModel)
+    }
+
     // show success message
     editCalendarModel.editSubscriptionModel.uiState.successMessage?.let { successMessage ->
         Toast.makeText(LocalContext.current, successMessage, Toast.LENGTH_LONG).show()
@@ -53,7 +66,11 @@ fun EditCalendarScreen(
             editCalendarModel.modelsDirty,
             editCalendarModel::onDelete,
             editCalendarModel::onSave,
-            onShare,
+            {
+                editSubscriptionModel.subscriptionWithCredential.value?.let {
+                    onShare(it.subscription)
+                }
+            },
             onExit
         )}
     ) { paddingValues ->
@@ -151,14 +168,15 @@ private fun AppBarComposable(
     )
 }
 
-@Preview
-@Composable
-fun EditCalendarScreen_Preview() {
-    AppTheme {
-        EditCalendarScreen(
-            editCalendarModel = viewModel(),
-            onShare = {},
-            onExit = {}
-        )
-    }
-}
+//@Preview
+//@Composable
+//fun EditCalendarScreen_Preview() {
+//    AppTheme {
+//        EditCalendarScreen(
+//            ,
+//            editCalendarModel = viewModel(),
+//            onShare = {},
+//            onExit = {}
+//        )
+//    }
+//}

--- a/app/src/main/java/at/bitfire/icsdroid/ui/screen/EditCalendarScreen.kt
+++ b/app/src/main/java/at/bitfire/icsdroid/ui/screen/EditCalendarScreen.kt
@@ -1,0 +1,272 @@
+package at.bitfire.icsdroid.ui.screen
+
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Check
+import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material.icons.filled.Share
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import at.bitfire.icsdroid.R
+import at.bitfire.icsdroid.model.CredentialsModel
+import at.bitfire.icsdroid.model.SubscriptionSettingsModel
+import at.bitfire.icsdroid.ui.partials.ExtendedTopAppBar
+import at.bitfire.icsdroid.ui.partials.GenericAlertDialog
+import at.bitfire.icsdroid.ui.theme.AppTheme
+import at.bitfire.icsdroid.ui.views.LoginCredentialsComposable
+import at.bitfire.icsdroid.ui.views.SubscriptionSettingsComposable
+
+@Composable
+fun EditCalendarScreen(
+    subscriptionSettingsModel: SubscriptionSettingsModel,
+    credentialsModel: CredentialsModel,
+    inputValid: Boolean,
+    modelsDirty: Boolean,
+    onDelete: () -> Unit,
+    onSave: () -> Unit,
+    onShare: () -> Unit,
+    onExit: () -> Unit
+) {
+    EditCalendarScreen(
+        credentialsModel.uiState.username,
+        credentialsModel.uiState.password,
+        credentialsModel.uiState.requiresAuth,
+
+        credentialsModel::setRequiresAuth,
+        credentialsModel::setUsername,
+        credentialsModel::setPassword,
+
+        subscriptionSettingsModel.uiState.supportsAuthentication,
+        subscriptionSettingsModel.uiState.url,
+        subscriptionSettingsModel.uiState.title,
+        subscriptionSettingsModel.uiState.color,
+        subscriptionSettingsModel.uiState.ignoreAlerts,
+        subscriptionSettingsModel.uiState.defaultAlarmMinutes,
+        subscriptionSettingsModel.uiState.defaultAllDayAlarmMinutes,
+        subscriptionSettingsModel.uiState.ignoreDescription,
+
+        subscriptionSettingsModel::setTitle,
+        subscriptionSettingsModel::setColor,
+        subscriptionSettingsModel::setIgnoreAlerts,
+        subscriptionSettingsModel::setDefaultAlarmMinutes,
+        subscriptionSettingsModel::setDefaultAllDayAlarmMinutes,
+        subscriptionSettingsModel::setIgnoreDescription,
+
+        inputValid,
+        modelsDirty,
+
+        onDelete,
+        onSave,
+        onShare,
+        onExit
+    )
+}
+
+@Composable
+private fun EditCalendarScreen(
+    username: String?,
+    password: String?,
+    requiresAuth: Boolean,
+
+    setRequiresAuth: (Boolean) -> Unit,
+    setUsername: (String) -> Unit,
+    setPassword: (String) -> Unit,
+
+    supportsAuthentication: Boolean,
+    url: String?,
+    title: String?,
+    color: Int?,
+    ignoreAlerts: Boolean,
+    defaultAlarmMinutes: Long?,
+    defaultAllDayAlarmMinutes: Long?,
+    ignoreDescription: Boolean,
+
+    setTitle: (String) -> Unit,
+    setColor: (Int) -> Unit,
+    setIgnoreAlerts: (Boolean) -> Unit,
+    setDefaultAlarmMinutes: (String) -> Unit,
+    setDefaultAllDayAlarmMinutes: (String) -> Unit,
+    setIgnoreDescription: (Boolean) -> Unit,
+
+    inputValid: Boolean,
+    modelsDirty: Boolean,
+
+    onDelete: () -> Unit,
+    onSave: () -> Unit,
+    onShare: () -> Unit,
+    onExit: () -> Unit
+) {
+    Scaffold(
+        topBar = { AppBarComposable(
+            inputValid,
+            modelsDirty,
+            onDelete,
+            onSave,
+            onShare,
+            onExit
+        )}
+    ) { paddingValues ->
+        Column(
+            Modifier
+                .verticalScroll(rememberScrollState())
+                .padding(paddingValues)
+                .padding(16.dp)
+        ) {
+            SubscriptionSettingsComposable(
+                url = url,
+                title = title,
+                titleChanged = setTitle,
+                color = color,
+                colorChanged = setColor,
+                ignoreAlerts = ignoreAlerts,
+                ignoreAlertsChanged = setIgnoreAlerts,
+                defaultAlarmMinutes = defaultAlarmMinutes,
+                defaultAlarmMinutesChanged = setDefaultAlarmMinutes,
+                defaultAllDayAlarmMinutes = defaultAllDayAlarmMinutes,
+                defaultAllDayAlarmMinutesChanged = setDefaultAllDayAlarmMinutes,
+                ignoreDescription = ignoreDescription,
+                onIgnoreDescriptionChanged = setIgnoreDescription,
+                isCreating = false,
+                modifier = Modifier.fillMaxWidth()
+            )
+            AnimatedVisibility(visible = supportsAuthentication) {
+                LoginCredentialsComposable(
+                    requiresAuth,
+                    username,
+                    password,
+                    onRequiresAuthChange = setRequiresAuth,
+                    onUsernameChange = setUsername,
+                    onPasswordChange = setPassword
+                )
+            }
+        }
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun AppBarComposable(
+    valid: Boolean,
+    modelsDirty: Boolean,
+    onDelete: () -> Unit,
+    onSave: () -> Unit,
+    onShare: () -> Unit,
+    onExit: () -> Unit
+) {
+    var openDeleteDialog by remember { mutableStateOf(false) }
+    if (openDeleteDialog)
+        GenericAlertDialog(
+            content = { Text(stringResource(R.string.edit_calendar_really_delete)) },
+            confirmButton = stringResource(R.string.edit_calendar_delete) to {
+                onDelete()
+                openDeleteDialog = false
+            },
+            dismissButton = stringResource(R.string.edit_calendar_cancel) to {
+                openDeleteDialog = false
+            },
+        ) { openDeleteDialog = false }
+    var openSaveDismissDialog by remember { mutableStateOf(false) }
+    if (openSaveDismissDialog) {
+        GenericAlertDialog(
+            content = { Text(text = if (valid)
+                stringResource(R.string.edit_calendar_unsaved_changes)
+            else
+                stringResource(R.string.edit_calendar_need_valid_credentials)
+            ) },
+            confirmButton = if (valid) stringResource(R.string.edit_calendar_save) to {
+                onSave()
+                openSaveDismissDialog = false
+            } else stringResource(R.string.edit_calendar_edit) to {
+                openSaveDismissDialog = false
+            },
+            dismissButton = stringResource(R.string.edit_calendar_dismiss) to onExit
+        ) { openSaveDismissDialog = false }
+    }
+    ExtendedTopAppBar(
+        navigationIcon = {
+            IconButton(
+                onClick = {
+                    if (modelsDirty)
+                        openSaveDismissDialog = true
+                    else
+                        onExit()
+                }
+            ) {
+                Icon(Icons.AutoMirrored.Filled.ArrowBack, null)
+            }
+        },
+        title = { Text(text = stringResource(R.string.activity_edit_calendar)) },
+        actions = {
+            IconButton(onClick = { onShare() }) {
+                Icon(
+                    Icons.Filled.Share,
+                    stringResource(R.string.edit_calendar_send_url)
+                )
+            }
+            IconButton(onClick = { openDeleteDialog = true }) {
+                Icon(Icons.Filled.Delete, stringResource(R.string.edit_calendar_delete))
+            }
+            AnimatedVisibility(visible = valid && modelsDirty) {
+                IconButton(onClick = { onSave() }) {
+                    Icon(Icons.Filled.Check, stringResource(R.string.edit_calendar_save))
+                }
+            }
+        }
+    )
+}
+
+@Preview
+@Composable
+fun EditCalendarScreen_Preview() {
+    AppTheme {
+        EditCalendarScreen(
+            username = "username",
+            password = "password",
+            requiresAuth = true,
+            setRequiresAuth = {},
+            setUsername = {},
+            setPassword = {},
+
+            supportsAuthentication = true,
+            url = "url",
+            title = "title",
+            color = 0,
+            ignoreAlerts = true,
+            defaultAlarmMinutes = 5L,
+            defaultAllDayAlarmMinutes = 10L,
+            ignoreDescription = false,
+            setTitle = {},
+            setColor = {},
+            setIgnoreAlerts = {},
+            setDefaultAlarmMinutes = {},
+            setDefaultAllDayAlarmMinutes = {},
+            setIgnoreDescription = {},
+
+            inputValid = true,
+            modelsDirty = true,
+
+            onDelete = {},
+            onSave = {},
+            onShare = {},
+            onExit = {}
+        )
+    }
+}

--- a/app/src/main/java/at/bitfire/icsdroid/ui/screen/EditCalendarScreen.kt
+++ b/app/src/main/java/at/bitfire/icsdroid/ui/screen/EditCalendarScreen.kt
@@ -27,8 +27,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import at.bitfire.icsdroid.R
-import at.bitfire.icsdroid.model.CredentialsModel
-import at.bitfire.icsdroid.model.SubscriptionSettingsModel
+import at.bitfire.icsdroid.model.EditCalendarModel
 import at.bitfire.icsdroid.ui.partials.ExtendedTopAppBar
 import at.bitfire.icsdroid.ui.partials.GenericAlertDialog
 import at.bitfire.icsdroid.ui.theme.AppTheme
@@ -37,52 +36,16 @@ import at.bitfire.icsdroid.ui.views.SubscriptionSettingsComposable
 
 @Composable
 fun EditCalendarScreen(
-    subscriptionSettingsModel: SubscriptionSettingsModel,
-    credentialsModel: CredentialsModel,
-    inputValid: Boolean,
-    modelsDirty: Boolean,
-    onDelete: () -> Unit,
-    onSave: () -> Unit,
-    onShare: () -> Unit,
-    onExit: () -> Unit
-) {
-    EditCalendarScreen(
-        subscriptionSettingsModel,
-        subscriptionSettingsModel.uiState.supportsAuthentication,
-
-        credentialsModel,
-
-        inputValid,
-        modelsDirty,
-
-        onDelete,
-        onSave,
-        onShare,
-        onExit
-    )
-}
-
-@Composable
-private fun EditCalendarScreen(
-    subscriptionSettingsModel: SubscriptionSettingsModel,
-    supportsAuthentication: Boolean,
-
-    credentialsModel: CredentialsModel,
-
-    inputValid: Boolean,
-    modelsDirty: Boolean,
-
-    onDelete: () -> Unit,
-    onSave: () -> Unit,
+    editCalendarModel: EditCalendarModel = viewModel(),
     onShare: () -> Unit,
     onExit: () -> Unit
 ) {
     Scaffold(
         topBar = { AppBarComposable(
-            inputValid,
-            modelsDirty,
-            onDelete,
-            onSave,
+            editCalendarModel.inputValid,
+            editCalendarModel.modelsDirty,
+            editCalendarModel::onDelete,
+            editCalendarModel::onSave,
             onShare,
             onExit
         )}
@@ -95,12 +58,14 @@ private fun EditCalendarScreen(
         ) {
             SubscriptionSettingsComposable(
                 modifier = Modifier.fillMaxWidth(),
-                subscriptionSettingsModel,
+                editCalendarModel.subscriptionSettingsModel,
                 isCreating = false
             )
-            AnimatedVisibility(visible = supportsAuthentication) {
+            AnimatedVisibility(
+                visible = editCalendarModel.subscriptionSettingsModel.uiState.supportsAuthentication
+            ) {
                 LoginCredentialsComposable(
-                    credentialsModel
+                    editCalendarModel.credentialsModel
                 )
             }
         }
@@ -184,16 +149,7 @@ private fun AppBarComposable(
 fun EditCalendarScreen_Preview() {
     AppTheme {
         EditCalendarScreen(
-            subscriptionSettingsModel = viewModel(),
-            supportsAuthentication = true,
-
-            credentialsModel = viewModel(),
-
-            inputValid = true,
-            modelsDirty = true,
-
-            onDelete = {},
-            onSave = {},
+            editCalendarModel = viewModel(),
             onShare = {},
             onExit = {}
         )

--- a/app/src/main/java/at/bitfire/icsdroid/ui/views/CredentialsComposable.kt
+++ b/app/src/main/java/at/bitfire/icsdroid/ui/views/CredentialsComposable.kt
@@ -33,21 +33,6 @@ import androidx.compose.ui.text.input.VisualTransformation
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import at.bitfire.icsdroid.R
-import at.bitfire.icsdroid.model.CredentialsModel
-
-@Composable
-fun LoginCredentialsComposable(
-    model: CredentialsModel
-) {
-    LoginCredentialsComposable(
-        model.uiState.requiresAuth,
-        model.uiState.username,
-        model.uiState.password,
-        onRequiresAuthChange = model::setRequiresAuth,
-        onUsernameChange = model::setUsername,
-        onPasswordChange = model::setPassword
-    )
-}
 
 @Composable
 fun LoginCredentialsComposable(

--- a/app/src/main/java/at/bitfire/icsdroid/ui/views/CredentialsComposable.kt
+++ b/app/src/main/java/at/bitfire/icsdroid/ui/views/CredentialsComposable.kt
@@ -33,6 +33,21 @@ import androidx.compose.ui.text.input.VisualTransformation
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import at.bitfire.icsdroid.R
+import at.bitfire.icsdroid.model.CredentialsModel
+
+@Composable
+fun LoginCredentialsComposable(
+    model: CredentialsModel
+) {
+    LoginCredentialsComposable(
+        model.uiState.requiresAuth,
+        model.uiState.username,
+        model.uiState.password,
+        onRequiresAuthChange = model::setRequiresAuth,
+        onUsernameChange = model::setUsername,
+        onPasswordChange = model::setPassword
+    )
+}
 
 @Composable
 fun LoginCredentialsComposable(

--- a/app/src/main/java/at/bitfire/icsdroid/ui/views/EditCalendarActivity.kt
+++ b/app/src/main/java/at/bitfire/icsdroid/ui/views/EditCalendarActivity.kt
@@ -8,18 +8,13 @@ import android.os.Bundle
 import android.widget.Toast
 import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
-import androidx.compose.runtime.Composable
-import androidx.compose.runtime.remember
 import androidx.core.app.ShareCompat
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
-import androidx.lifecycle.flowWithLifecycle
 import androidx.lifecycle.lifecycleScope
 import at.bitfire.icsdroid.R
-import at.bitfire.icsdroid.db.dao.SubscriptionsDao
-import at.bitfire.icsdroid.db.entity.Credential
-import at.bitfire.icsdroid.db.entity.Subscription
 import at.bitfire.icsdroid.model.CredentialsModel
+import at.bitfire.icsdroid.model.EditCalendarModel
 import at.bitfire.icsdroid.model.EditSubscriptionModel
 import at.bitfire.icsdroid.model.SubscriptionSettingsModel
 import at.bitfire.icsdroid.ui.screen.EditCalendarScreen
@@ -33,45 +28,9 @@ class EditCalendarActivity: AppCompatActivity() {
     }
 
     private val subscriptionSettingsModel by viewModels<SubscriptionSettingsModel>()
-    private var initialSubscription: Subscription? = null
     private val credentialsModel by viewModels<CredentialsModel>()
-    private var initialCredential: Credential? = null
-    private var initialRequiresAuthValue: Boolean? = null
 
-    // Whether user made changes are legal
-    private val inputValid: Boolean
-        @Composable
-        get() = remember(subscriptionSettingsModel.uiState, credentialsModel.uiState) {
-            val title = subscriptionSettingsModel.uiState.title
-            val requiresAuth = credentialsModel.uiState.requiresAuth
-            val username = credentialsModel.uiState.username
-            val password = credentialsModel.uiState.password
-
-            val titleOK = !title.isNullOrBlank()
-            val authOK = if (requiresAuth)
-                !username.isNullOrBlank() && !password.isNullOrBlank()
-            else
-                true
-            titleOK && authOK
-        }
-
-    // Whether unsaved changes exist
-    private val modelsDirty: Boolean
-        @Composable
-        get() = remember(subscriptionSettingsModel.uiState, credentialsModel.uiState) {
-            val requiresAuth = credentialsModel.uiState.requiresAuth
-
-            val credentialsDirty = initialRequiresAuthValue != requiresAuth ||
-                    initialCredential?.let { !credentialsModel.equalsCredential(it) } ?: false
-            val subscriptionsDirty = initialSubscription?.let {
-                !subscriptionSettingsModel.equalsSubscription(it)
-            } ?: false
-
-            credentialsDirty || subscriptionsDirty
-        }
-
-
-    private val model by viewModels<EditSubscriptionModel> {
+    private val editSubscriptionModel by viewModels<EditSubscriptionModel> {
         object: ViewModelProvider.Factory {
             @Suppress("UNCHECKED_CAST")
             override fun <T : ViewModel> create(modelClass: Class<T>): T {
@@ -84,16 +43,8 @@ class EditCalendarActivity: AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
-        // Initialise view models and save their initial state
-        lifecycleScope.launch {
-            model.subscriptionWithCredential.flowWithLifecycle(lifecycle).collect { data ->
-                if (data != null)
-                    onSubscriptionLoaded(data)
-            }
-        }
-
         setContentThemed {
-            val successMessage = model.uiState.successMessage
+            val successMessage = editSubscriptionModel.uiState.successMessage
             // show success message
             successMessage?.let {
                 Toast.makeText(this, it, Toast.LENGTH_LONG).show()
@@ -101,59 +52,23 @@ class EditCalendarActivity: AppCompatActivity() {
             }
 
             EditCalendarScreen(
-                subscriptionSettingsModel,
-                credentialsModel,
-                inputValid,
-                modelsDirty,
-                { onDelete() },
-                { onSave() },
+                EditCalendarModel(
+                    editSubscriptionModel,
+                    subscriptionSettingsModel,
+                    credentialsModel
+                ),
                 { onShare() },
                 { finish() }
             )
         }
     }
 
-    /**
-     * Initialise view models and remember their initial state
-     */
-    private fun onSubscriptionLoaded(subscriptionWithCredential: SubscriptionsDao.SubscriptionWithCredential) {
-        val subscription = subscriptionWithCredential.subscription
-
-        subscriptionSettingsModel.setUrl(subscription.url.toString())
-        subscription.displayName.let {
-            subscriptionSettingsModel.setTitle(it)
-        }
-        subscription.color.let(subscriptionSettingsModel::setColor)
-        subscription.ignoreEmbeddedAlerts.let(subscriptionSettingsModel::setIgnoreAlerts)
-        subscription.defaultAlarmMinutes?.toString().let(subscriptionSettingsModel::setDefaultAlarmMinutes)
-        subscription.defaultAllDayAlarmMinutes?.toString()?.let(subscriptionSettingsModel::setDefaultAllDayAlarmMinutes)
-        subscription.ignoreDescription.let(subscriptionSettingsModel::setIgnoreDescription)
-
-        val credential = subscriptionWithCredential.credential
-        val requiresAuth = credential != null
-        credentialsModel.setRequiresAuth(requiresAuth)
-
-        if (credential != null) {
-            credential.username.let(credentialsModel::setUsername)
-            credential.password.let(credentialsModel::setPassword)
-        }
-
-        // Save state, before user makes changes
-        initialSubscription = subscription
-        initialCredential = credential
-        initialRequiresAuthValue = credentialsModel.uiState.requiresAuth
-    }
-
 
     /* user actions */
 
-    private fun onSave() = model.updateSubscription(subscriptionSettingsModel, credentialsModel)
-
-    private fun onDelete() = model.removeSubscription()
-
     private fun onShare() {
         lifecycleScope.launch {
-            model.subscriptionWithCredential.value?.let { (subscription, _) ->
+            editSubscriptionModel.subscriptionWithCredential.value?.let { (subscription, _) ->
                 ShareCompat.IntentBuilder(this@EditCalendarActivity)
                     .setSubject(subscription.displayName)
                     .setText(subscription.url.toString())

--- a/app/src/main/java/at/bitfire/icsdroid/ui/views/EditCalendarActivity.kt
+++ b/app/src/main/java/at/bitfire/icsdroid/ui/views/EditCalendarActivity.kt
@@ -5,7 +5,6 @@
 package at.bitfire.icsdroid.ui.views
 
 import android.os.Bundle
-import android.widget.Toast
 import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.app.ShareCompat
@@ -42,15 +41,7 @@ class EditCalendarActivity: AppCompatActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-
         setContentThemed {
-            val successMessage = editSubscriptionModel.uiState.successMessage
-            // show success message
-            successMessage?.let {
-                Toast.makeText(this, it, Toast.LENGTH_LONG).show()
-                finish()
-            }
-
             EditCalendarScreen(
                 EditCalendarModel(
                     editSubscriptionModel,

--- a/app/src/main/java/at/bitfire/icsdroid/ui/views/EditCalendarActivity.kt
+++ b/app/src/main/java/at/bitfire/icsdroid/ui/views/EditCalendarActivity.kt
@@ -5,45 +5,16 @@
 package at.bitfire.icsdroid.ui.views
 
 import android.os.Bundle
-import android.util.Log
 import android.widget.Toast
 import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
-import androidx.compose.animation.AnimatedVisibility
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.verticalScroll
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.automirrored.filled.ArrowBack
-import androidx.compose.material.icons.filled.Check
-import androidx.compose.material.icons.filled.Delete
-import androidx.compose.material.icons.filled.Share
-import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
-import androidx.compose.material3.Scaffold
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
-import androidx.compose.ui.Modifier
-import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.tooling.preview.Preview
-import androidx.compose.ui.unit.dp
 import androidx.core.app.ShareCompat
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
-import androidx.lifecycle.compose.collectAsStateWithLifecycle
-import androidx.lifecycle.coroutineScope
 import androidx.lifecycle.flowWithLifecycle
 import androidx.lifecycle.lifecycleScope
-import androidx.lifecycle.viewModelScope
-import at.bitfire.icsdroid.Constants
 import at.bitfire.icsdroid.R
 import at.bitfire.icsdroid.db.dao.SubscriptionsDao
 import at.bitfire.icsdroid.db.entity.Credential
@@ -51,12 +22,8 @@ import at.bitfire.icsdroid.db.entity.Subscription
 import at.bitfire.icsdroid.model.CredentialsModel
 import at.bitfire.icsdroid.model.EditSubscriptionModel
 import at.bitfire.icsdroid.model.SubscriptionSettingsModel
-import at.bitfire.icsdroid.ui.partials.ExtendedTopAppBar
-import at.bitfire.icsdroid.ui.partials.GenericAlertDialog
+import at.bitfire.icsdroid.ui.screen.EditCalendarScreen
 import at.bitfire.icsdroid.ui.theme.setContentThemed
-import kotlinx.coroutines.flow.SharingStarted
-import kotlinx.coroutines.flow.combine
-import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 
 class EditCalendarActivity: AppCompatActivity() {
@@ -133,7 +100,16 @@ class EditCalendarActivity: AppCompatActivity() {
                 finish()
             }
 
-            EditCalendarComposable()
+            EditCalendarScreen(
+                subscriptionSettingsModel,
+                credentialsModel,
+                inputValid,
+                modelsDirty,
+                { onDelete() },
+                { onSave() },
+                { onShare() },
+                { finish() }
+            )
         }
     }
 
@@ -186,132 +162,6 @@ class EditCalendarActivity: AppCompatActivity() {
                     .startChooser()
             }
         }
-    }
-
-    /* Composables */
-
-    @Composable
-    private fun EditCalendarComposable() {
-        val url = subscriptionSettingsModel.uiState.url
-        val title = subscriptionSettingsModel.uiState.title
-        val color = subscriptionSettingsModel.uiState.color
-        val ignoreAlerts = subscriptionSettingsModel.uiState.ignoreAlerts
-        val defaultAlarmMinutes = subscriptionSettingsModel.uiState.defaultAlarmMinutes
-        val defaultAllDayAlarmMinutes = subscriptionSettingsModel.uiState.defaultAllDayAlarmMinutes
-        val ignoreDescription = subscriptionSettingsModel.uiState.ignoreDescription
-        Scaffold(
-            topBar = { AppBarComposable(inputValid, modelsDirty) }
-        ) { paddingValues ->
-            Column(
-                Modifier
-                    .verticalScroll(rememberScrollState())
-                    .padding(paddingValues)
-                    .padding(16.dp)
-            ) {
-                SubscriptionSettingsComposable(
-                    url = url,
-                    title = title,
-                    titleChanged = subscriptionSettingsModel::setTitle,
-                    color = color,
-                    colorChanged = subscriptionSettingsModel::setColor,
-                    ignoreAlerts = ignoreAlerts,
-                    ignoreAlertsChanged = subscriptionSettingsModel::setIgnoreAlerts,
-                    defaultAlarmMinutes = defaultAlarmMinutes,
-                    defaultAlarmMinutesChanged = subscriptionSettingsModel::setDefaultAlarmMinutes,
-                    defaultAllDayAlarmMinutes = defaultAllDayAlarmMinutes,
-                    defaultAllDayAlarmMinutesChanged = subscriptionSettingsModel::setDefaultAllDayAlarmMinutes,
-                    ignoreDescription = ignoreDescription,
-                    onIgnoreDescriptionChanged = subscriptionSettingsModel::setIgnoreDescription,
-                    isCreating = false,
-                    modifier = Modifier.fillMaxWidth()
-                )
-                val supportsAuthentication = subscriptionSettingsModel.uiState.supportsAuthentication
-                val requiresAuth: Boolean = credentialsModel.uiState.requiresAuth
-                val username: String? = credentialsModel.uiState.username
-                val password: String? = credentialsModel.uiState.password
-                AnimatedVisibility(visible = supportsAuthentication) {
-                    LoginCredentialsComposable(
-                        requiresAuth,
-                        username,
-                        password,
-                        onRequiresAuthChange = credentialsModel::setRequiresAuth,
-                        onUsernameChange = credentialsModel::setUsername,
-                        onPasswordChange = credentialsModel::setPassword
-                    )
-                }
-            }
-        }
-    }
-
-    @OptIn(ExperimentalMaterial3Api::class)
-    @Composable
-    private fun AppBarComposable(valid: Boolean, modelsDirty: Boolean) {
-        var openDeleteDialog by remember { mutableStateOf(false) }
-        if (openDeleteDialog)
-            GenericAlertDialog(
-                content = { Text(stringResource(R.string.edit_calendar_really_delete)) },
-                confirmButton = stringResource(R.string.edit_calendar_delete) to {
-                    onDelete()
-                    openDeleteDialog = false
-                },
-                dismissButton = stringResource(R.string.edit_calendar_cancel) to {
-                    openDeleteDialog = false
-                                                                                 },
-            ) { openDeleteDialog = false }
-        var openSaveDismissDialog by remember { mutableStateOf(false) }
-        if (openSaveDismissDialog) {
-            GenericAlertDialog(
-                content = { Text(text = if (valid)
-                    stringResource(R.string.edit_calendar_unsaved_changes)
-                else
-                    stringResource(R.string.edit_calendar_need_valid_credentials)
-                ) },
-                confirmButton = if (valid) stringResource(R.string.edit_calendar_save) to {
-                    onSave()
-                    openSaveDismissDialog = false
-                } else stringResource(R.string.edit_calendar_edit) to {
-                    openSaveDismissDialog = false
-                },
-                dismissButton = stringResource(R.string.edit_calendar_dismiss) to ::finish
-            ) { openSaveDismissDialog = false }
-        }
-        ExtendedTopAppBar(
-            navigationIcon = {
-                IconButton(
-                    onClick = {
-                        if (modelsDirty)
-                            openSaveDismissDialog = true
-                        else
-                            finish()
-                    }
-                ) {
-                    Icon(Icons.AutoMirrored.Filled.ArrowBack, null)
-                }
-            },
-            title = { Text(text = stringResource(R.string.activity_edit_calendar)) },
-            actions = {
-                IconButton(onClick = { onShare() }) {
-                    Icon(
-                        Icons.Filled.Share,
-                        stringResource(R.string.edit_calendar_send_url)
-                    )
-                }
-                IconButton(onClick = { openDeleteDialog = true }) {
-                    Icon(Icons.Filled.Delete, stringResource(R.string.edit_calendar_delete))
-                }
-                AnimatedVisibility(visible = valid && modelsDirty) {
-                    IconButton(onClick = { onSave() }) {
-                        Icon(Icons.Filled.Check, stringResource(R.string.edit_calendar_save))
-                    }
-                }
-            }
-        )
-    }
-
-    @Preview
-    @Composable
-    fun TopBarComposable_Preview() {
-        AppBarComposable(valid = true, modelsDirty = true)
     }
 
 }

--- a/app/src/main/java/at/bitfire/icsdroid/ui/views/EditCalendarActivity.kt
+++ b/app/src/main/java/at/bitfire/icsdroid/ui/views/EditCalendarActivity.kt
@@ -5,69 +5,38 @@
 package at.bitfire.icsdroid.ui.views
 
 import android.os.Bundle
-import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.app.ShareCompat
-import androidx.lifecycle.ViewModel
-import androidx.lifecycle.ViewModelProvider
-import androidx.lifecycle.lifecycleScope
 import at.bitfire.icsdroid.R
-import at.bitfire.icsdroid.model.CredentialsModel
-import at.bitfire.icsdroid.model.EditCalendarModel
-import at.bitfire.icsdroid.model.EditSubscriptionModel
-import at.bitfire.icsdroid.model.SubscriptionSettingsModel
+import at.bitfire.icsdroid.db.entity.Subscription
 import at.bitfire.icsdroid.ui.screen.EditCalendarScreen
 import at.bitfire.icsdroid.ui.theme.setContentThemed
-import kotlinx.coroutines.launch
 
 class EditCalendarActivity: AppCompatActivity() {
 
     companion object {
+        // Used by intents only
         const val EXTRA_SUBSCRIPTION_ID = "subscriptionId"
-    }
-
-    private val subscriptionSettingsModel by viewModels<SubscriptionSettingsModel>()
-    private val credentialsModel by viewModels<CredentialsModel>()
-
-    private val editSubscriptionModel by viewModels<EditSubscriptionModel> {
-        object: ViewModelProvider.Factory {
-            @Suppress("UNCHECKED_CAST")
-            override fun <T : ViewModel> create(modelClass: Class<T>): T {
-                val subscriptionId = intent.getLongExtra(EXTRA_SUBSCRIPTION_ID, -1)
-                return EditSubscriptionModel(application, subscriptionId) as T
-            }
-        }
     }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentThemed {
             EditCalendarScreen(
-                EditCalendarModel(
-                    editSubscriptionModel,
-                    subscriptionSettingsModel,
-                    credentialsModel
-                ),
-                { onShare() },
+                application,
+                subscriptionId = intent.getLongExtra(EXTRA_SUBSCRIPTION_ID, -1),
+                { onShare(it) },
                 { finish() }
             )
         }
     }
 
-
-    /* user actions */
-
-    private fun onShare() {
-        lifecycleScope.launch {
-            editSubscriptionModel.subscriptionWithCredential.value?.let { (subscription, _) ->
-                ShareCompat.IntentBuilder(this@EditCalendarActivity)
-                    .setSubject(subscription.displayName)
-                    .setText(subscription.url.toString())
-                    .setType("text/plain")
-                    .setChooserTitle(R.string.edit_calendar_send_url)
-                    .startChooser()
-            }
-        }
-    }
+    private fun onShare(subscription: Subscription) =
+        ShareCompat.IntentBuilder(this)
+            .setSubject(subscription.displayName)
+            .setText(subscription.url.toString())
+            .setType("text/plain")
+            .setChooserTitle(R.string.edit_calendar_send_url)
+            .startChooser()
 
 }

--- a/app/src/main/java/at/bitfire/icsdroid/ui/views/SubscriptionSettingsComposable.kt
+++ b/app/src/main/java/at/bitfire/icsdroid/ui/views/SubscriptionSettingsComposable.kt
@@ -32,11 +32,38 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.lifecycle.viewmodel.compose.viewModel
 import at.bitfire.icsdroid.R
 import at.bitfire.icsdroid.calendar.LocalCalendar
+import at.bitfire.icsdroid.model.SubscriptionSettingsModel
 import at.bitfire.icsdroid.ui.partials.ColorPickerDialog
 import at.bitfire.icsdroid.ui.partials.SwitchSetting
 import at.bitfire.icsdroid.ui.theme.AppTheme
+
+@Composable
+fun SubscriptionSettingsComposable(
+    model: SubscriptionSettingsModel = viewModel(),
+    isCreating: Boolean = false,
+    modifier: Modifier = Modifier
+) {
+    SubscriptionSettingsComposable(
+        url = model.uiState.url,
+        title = model.uiState.title,
+        titleChanged = model::setTitle,
+        color = model.uiState.color,
+        colorChanged = model::setColor,
+        ignoreAlerts = model.uiState.ignoreAlerts,
+        ignoreAlertsChanged = model::setIgnoreAlerts,
+        defaultAlarmMinutes = model.uiState.defaultAlarmMinutes,
+        defaultAlarmMinutesChanged = model::setDefaultAlarmMinutes,
+        defaultAllDayAlarmMinutes = model.uiState.defaultAllDayAlarmMinutes,
+        defaultAllDayAlarmMinutesChanged = model::setDefaultAllDayAlarmMinutes,
+        ignoreDescription = model.uiState.ignoreDescription,
+        onIgnoreDescriptionChanged = model::setIgnoreDescription,
+        isCreating = isCreating,
+        modifier = modifier
+    )
+}
 
 @Composable
 fun SubscriptionSettingsComposable(

--- a/app/src/main/java/at/bitfire/icsdroid/ui/views/SubscriptionSettingsComposable.kt
+++ b/app/src/main/java/at/bitfire/icsdroid/ui/views/SubscriptionSettingsComposable.kt
@@ -30,11 +30,13 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import at.bitfire.icsdroid.R
 import at.bitfire.icsdroid.calendar.LocalCalendar
 import at.bitfire.icsdroid.ui.partials.ColorPickerDialog
 import at.bitfire.icsdroid.ui.partials.SwitchSetting
+import at.bitfire.icsdroid.ui.theme.AppTheme
 
 @Composable
 fun SubscriptionSettingsComposable(
@@ -184,8 +186,31 @@ fun SubscriptionSettingsComposable(
         SwitchSetting(
             title = stringResource(R.string.add_calendar_description_title),
             description = stringResource(R.string.add_calendar_description_summary),
-            checked = ignoreDescription ?: false,
+            checked = ignoreDescription,
             onCheckedChange = onIgnoreDescriptionChanged
+        )
+    }
+}
+
+@Preview
+@Composable
+fun SubscriptionSettingsComposable_Preview() {
+    AppTheme {
+        SubscriptionSettingsComposable(
+            url = "url",
+            title = "title",
+            titleChanged = {},
+            color = 0,
+            colorChanged = {},
+            ignoreAlerts = true,
+            ignoreAlertsChanged = {},
+            defaultAlarmMinutes = 20L,
+            defaultAlarmMinutesChanged = {},
+            defaultAllDayAlarmMinutes = 10L,
+            defaultAllDayAlarmMinutesChanged = {},
+            ignoreDescription = false,
+            onIgnoreDescriptionChanged = {},
+            isCreating = true
         )
     }
 }

--- a/app/src/main/java/at/bitfire/icsdroid/ui/views/SubscriptionSettingsComposable.kt
+++ b/app/src/main/java/at/bitfire/icsdroid/ui/views/SubscriptionSettingsComposable.kt
@@ -32,38 +32,11 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import androidx.lifecycle.viewmodel.compose.viewModel
 import at.bitfire.icsdroid.R
 import at.bitfire.icsdroid.calendar.LocalCalendar
-import at.bitfire.icsdroid.model.SubscriptionSettingsModel
 import at.bitfire.icsdroid.ui.partials.ColorPickerDialog
 import at.bitfire.icsdroid.ui.partials.SwitchSetting
 import at.bitfire.icsdroid.ui.theme.AppTheme
-
-@Composable
-fun SubscriptionSettingsComposable(
-    modifier: Modifier = Modifier,
-    model: SubscriptionSettingsModel = viewModel(),
-    isCreating: Boolean = false
-) {
-    SubscriptionSettingsComposable(
-        url = model.uiState.url,
-        title = model.uiState.title,
-        titleChanged = model::setTitle,
-        color = model.uiState.color,
-        colorChanged = model::setColor,
-        ignoreAlerts = model.uiState.ignoreAlerts,
-        ignoreAlertsChanged = model::setIgnoreAlerts,
-        defaultAlarmMinutes = model.uiState.defaultAlarmMinutes,
-        defaultAlarmMinutesChanged = model::setDefaultAlarmMinutes,
-        defaultAllDayAlarmMinutes = model.uiState.defaultAllDayAlarmMinutes,
-        defaultAllDayAlarmMinutesChanged = model::setDefaultAllDayAlarmMinutes,
-        ignoreDescription = model.uiState.ignoreDescription,
-        onIgnoreDescriptionChanged = model::setIgnoreDescription,
-        isCreating = isCreating,
-        modifier = modifier
-    )
-}
 
 @Composable
 fun SubscriptionSettingsComposable(

--- a/app/src/main/java/at/bitfire/icsdroid/ui/views/SubscriptionSettingsComposable.kt
+++ b/app/src/main/java/at/bitfire/icsdroid/ui/views/SubscriptionSettingsComposable.kt
@@ -42,9 +42,9 @@ import at.bitfire.icsdroid.ui.theme.AppTheme
 
 @Composable
 fun SubscriptionSettingsComposable(
+    modifier: Modifier = Modifier,
     model: SubscriptionSettingsModel = viewModel(),
-    isCreating: Boolean = false,
-    modifier: Modifier = Modifier
+    isCreating: Boolean = false
 ) {
     SubscriptionSettingsComposable(
         url = model.uiState.url,


### PR DESCRIPTION
### Purpose

As part of the switch to compose state and kotlin flows we also moved the code around as discussed in the guidelines for DAVx5. This PR applies these changes in the remaining EditCalendarActvivity.

### Short description

 - Extract composables
 - handle view model creation in composables
 - introduce a new EditCalendarModel, which 
   - does the dirty view-model check 
   - validation
   - initializes other models (could maybe be rewritten to proper flow mapping and collection later on)
- leave intent logic in the activity

### Checklist

- [X] The PR has a proper title, description and label.
- [X] I have [self-reviewed the PR](https://patrickdinh.medium.com/review-your-own-pull-requests-5634cad10b7a).
- [X] I have added documentation to complex functions and functions that can be used by other modules.
- [X] I have added reasonable tests or consciously decided to not add tests.
