### PR TITLE
Fix workers piling up

### DIFF
--- a/app/src/main/java/at/bitfire/icsdroid/PeriodicSyncWorker.kt
+++ b/app/src/main/java/at/bitfire/icsdroid/PeriodicSyncWorker.kt
@@ -5,8 +5,12 @@
 package at.bitfire.icsdroid
 
 import android.content.Context
-import android.util.Log
-import androidx.work.*
+import androidx.work.Constraints
+import androidx.work.ExistingPeriodicWorkPolicy
+import androidx.work.NetworkType
+import androidx.work.PeriodicWorkRequestBuilder
+import androidx.work.WorkManager
+import androidx.work.WorkerParameters
 import java.time.Duration
 
 class PeriodicSyncWorker(
@@ -26,7 +30,7 @@ class PeriodicSyncWorker(
                         .setRequiredNetworkType(NetworkType.CONNECTED)      // network connection is usually required for synchronization
                         .build())
                     .build()
-                wm.enqueueUniquePeriodicWork(NAME, ExistingPeriodicWorkPolicy.UPDATE, request)
+                wm.enqueueUniquePeriodicWork(NAME, ExistingPeriodicWorkPolicy.CANCEL_AND_REENQUEUE, request)
             } else
                 wm.cancelUniqueWork(NAME)
         }


### PR DESCRIPTION
### Purpose

Fix workers piling up.

### Short description

Switch back to replace aka cancel and reenqueue periodic workers.

- Switch back #REPLACE or rather [#CANCEL_AND_REENQUEUE](https://developer.android.com/reference/androidx/work/ExistingPeriodicWorkPolicy#CANCEL_AND_REENQUEUE) since thats the new name for #REPLACE.
- optimize imports

### Checklist

- [X] The PR has a proper title, description and label.
- [X] I have [self-reviewed the PR](https://patrickdinh.medium.com/review-your-own-pull-requests-5634cad10b7a).