### PR TITLE
Stop subscription form covering the loading indicator

### DIFF
--- a/app/src/main/java/at/bitfire/icsdroid/ui/views/EnterUrlComposable.kt
+++ b/app/src/main/java/at/bitfire/icsdroid/ui/views/EnterUrlComposable.kt
@@ -104,9 +104,6 @@ fun EnterUrlComposable(
     Scaffold(
         snackbarHost = { SnackbarHost(snackbarHostState) }
     ) { paddingValues ->
-        AnimatedVisibility(isVerifyingUrl) {
-            LinearProgressIndicator(Modifier.fillMaxWidth())
-        }
         Column(
             modifier = Modifier
                     .fillMaxSize()
@@ -114,6 +111,10 @@ fun EnterUrlComposable(
                     .padding(horizontal = 16.dp)
                     .verticalScroll(rememberScrollState())
         ) {
+            AnimatedVisibility(isVerifyingUrl) {
+                LinearProgressIndicator(Modifier.fillMaxWidth())
+            }
+
             val scope = rememberCoroutineScope()
             val state = rememberPagerState(pageCount = { 2 })
 

--- a/app/src/main/java/at/bitfire/icsdroid/ui/views/EnterUrlComposable.kt
+++ b/app/src/main/java/at/bitfire/icsdroid/ui/views/EnterUrlComposable.kt
@@ -108,7 +108,6 @@ fun EnterUrlComposable(
             modifier = Modifier
                     .fillMaxSize()
                     .padding(paddingValues)
-                    .padding(horizontal = 16.dp)
                     .verticalScroll(rememberScrollState())
         ) {
             AnimatedVisibility(isVerifyingUrl) {
@@ -118,7 +117,10 @@ fun EnterUrlComposable(
             val scope = rememberCoroutineScope()
             val state = rememberPagerState(pageCount = { 2 })
 
-            TabRow(state.currentPage) {
+            TabRow(
+                state.currentPage,
+                modifier = Modifier.padding(horizontal = 16.dp)
+            ) {
                 Tab(state.currentPage == 0, onClick = {
                     onUrlChange(null)
                     scope.launch { state.scrollToPage(0) }},
@@ -169,6 +171,7 @@ fun EnterUrlComposable(
                 state,
                 modifier = Modifier
                     .fillMaxWidth()
+                    .padding(horizontal = 16.dp)
                     .weight(1f),
                 verticalAlignment = Alignment.Top
             ) { index ->


### PR DESCRIPTION
### Purpose

Stop the subscription form from covering the loading indicator #329 

### Short description

- moved progress indicator bar into column
- adjusted padding

### Checklist

- [X] The PR has a proper title, description and label.
- [X] I have [self-reviewed the PR](https://patrickdinh.medium.com/review-your-own-pull-requests-5634cad10b7a).
