### PR TITLE
Part of the query is removed when URL is passed in Intent

### DIFF
--- a/app/src/main/java/at/bitfire/icsdroid/UriUtils.kt
+++ b/app/src/main/java/at/bitfire/icsdroid/UriUtils.kt
@@ -32,4 +32,23 @@ object UriUtils {
 
         return false
     }
+
+    /**
+     * Strips the URL from a string. For example, the following string:
+     * ```
+     * "This is a URL: https://example.com"
+     * ```
+     * will return:
+     * ```
+     * "https://example.com"
+     * ```
+     * _Quotes are not included_
+     * @return The URL found in the string
+     * @throws IllegalArgumentException if no URL is found in the string
+     */
+    fun String.stripUrl(): String? {
+        return "([a-zA-Z]+)://(\\w+)(.\\w+)*[/\\w*]*".toRegex()
+            .find(this)
+            ?.value
+    }
 }

--- a/app/src/main/java/at/bitfire/icsdroid/UriUtils.kt
+++ b/app/src/main/java/at/bitfire/icsdroid/UriUtils.kt
@@ -47,7 +47,7 @@ object UriUtils {
      * @throws IllegalArgumentException if no URL is found in the string
      */
     fun String.stripUrl(): String? {
-        return "([a-zA-Z]+)://(\\w+)(.\\w+)*[/\\w*]*".toRegex()
+        return "([a-zA-Z]+)://(\\w+)(.\\w+)*[\\w.&?=*]*".toRegex()
             .find(this)
             ?.value
     }

--- a/app/src/main/java/at/bitfire/icsdroid/ui/views/AddCalendarActivity.kt
+++ b/app/src/main/java/at/bitfire/icsdroid/ui/views/AddCalendarActivity.kt
@@ -21,6 +21,7 @@ import androidx.compose.ui.platform.LocalContext
 import at.bitfire.icsdroid.Constants
 import at.bitfire.icsdroid.HttpClient
 import at.bitfire.icsdroid.R
+import at.bitfire.icsdroid.UriUtils.stripUrl
 import at.bitfire.icsdroid.calendar.LocalCalendar
 import at.bitfire.icsdroid.model.CreateSubscriptionModel
 import at.bitfire.icsdroid.model.CredentialsModel
@@ -146,25 +147,6 @@ class AddCalendarActivity : AppCompatActivity() {
     override fun onResume() {
         super.onResume()
         HttpClient.setForeground(true)
-    }
-
-    /**
-     * Strips the URL from a string. For example, the following string:
-     * ```
-     * "This is a URL: https://example.com"
-     * ```
-     * will return:
-     * ```
-     * "https://example.com"
-     * ```
-     * _Quotes are not included_
-     * @return The URL found in the string
-     * @throws IllegalArgumentException if no URL is found in the string
-     */
-    private fun String.stripUrl(): String? {
-        return "([a-zA-Z]+)://(\\w+)(.\\w+)*[/\\w*]*".toRegex()
-            .find(this)
-            ?.value
     }
 
 }

--- a/app/src/test/kotlin/at/bitfire/icsdroid/UrlUtilsTest.kt
+++ b/app/src/test/kotlin/at/bitfire/icsdroid/UrlUtilsTest.kt
@@ -7,8 +7,8 @@ import org.junit.Test
 class UrlUtilsTest {
     @Test
     fun testStripUrl() {
-        val url = "This is a URL: https://example.com/more/and/more?query=true.&param=test.more"
+        val url = "This is a URL: https://example.com/more/and/more?query=true.&par_am=test.more"
         val strippedUrl = url.stripUrl()
-        assertEquals("https://example.com/more/and/more?query=true_&param=test.more", strippedUrl)
+        assertEquals("https://example.com/more/and/more?query=true.&par_am=test.more", strippedUrl)
     }
 }

--- a/app/src/test/kotlin/at/bitfire/icsdroid/UrlUtilsTest.kt
+++ b/app/src/test/kotlin/at/bitfire/icsdroid/UrlUtilsTest.kt
@@ -1,0 +1,14 @@
+package at.bitfire.icsdroid
+
+import at.bitfire.icsdroid.UriUtils.stripUrl
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class UrlUtilsTest {
+    @Test
+    fun testStripUrl() {
+        val url = "This is a URL: https://example.com/more/and/more?query=true.&param=test.more"
+        val strippedUrl = url.stripUrl()
+        assertEquals("https://example.com/more/and/more?query=true_&param=test.more", strippedUrl)
+    }
+}


### PR DESCRIPTION
### Purpose

See #342. A part of the query of URLs is stripped.

### Short description

After adding a test case, I've discovered that the RegExp is not correct, it was not picking dots.

- Updated Regex to `([a-zA-Z]+)://(\w+)(.\w+)*[\w.&?=*]*`.
- Added test case.

### Checklist

- [x] The PR has a proper title, description and label.
- [x] I have [self-reviewed the PR](https://patrickdinh.medium.com/review-your-own-pull-requests-5634cad10b7a).
- [x] I have added documentation to complex functions and functions that can be used by other modules.
- [x] I have added reasonable tests or consciously decided to not add tests.
