### PR TITLE
Donation dialog does not show button on standard

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -121,6 +121,7 @@ dependencies {
     implementation(libs.androidx.activityCompose)
     implementation(libs.androidx.appCompat)
     implementation(libs.androidx.core)
+    implementation(libs.androidx.datastore)
     implementation(libs.androidx.lifecycle.viewmodel)
     implementation(libs.androidx.lifecycle.viewmodel.compose)
     implementation(libs.androidx.lifecycle.runtime.compose)

--- a/app/src/androidTest/java/at/bitfire/icsdroid/ComposableStartupServiceTest.kt
+++ b/app/src/androidTest/java/at/bitfire/icsdroid/ComposableStartupServiceTest.kt
@@ -1,0 +1,44 @@
+package at.bitfire.icsdroid
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.State
+import at.bitfire.icsdroid.service.ComposableStartupService
+import at.bitfire.icsdroid.service.ComposableStartupService.Companion.FLAG_DONATION_DIALOG
+import org.junit.Test
+
+class ComposableStartupServiceTest {
+    private fun createService(vararg flags: Int): ComposableStartupService {
+        return object : ComposableStartupService {
+            override val flags: Int = flags.sum()
+
+            @Composable
+            override fun shouldShow(): State<Boolean> {
+                TODO("Not yet implemented")
+            }
+
+            @Composable
+            override fun Content() {
+                TODO("Not yet implemented")
+            }
+        }
+    }
+
+    @Test
+    fun testHasFlagNoFlags() {
+        val service = createService()
+        assert(!service.hasFlag(FLAG_DONATION_DIALOG))
+    }
+
+    @Test
+    fun testHasFlagSingleFlag() {
+        val service = createService(FLAG_DONATION_DIALOG)
+        assert(service.hasFlag(FLAG_DONATION_DIALOG))
+    }
+
+    @Test
+    fun testHasFlagMultipleFlag() {
+        val service = createService(FLAG_DONATION_DIALOG, 0b10)
+        assert(service.hasFlag(FLAG_DONATION_DIALOG))
+        assert(service.hasFlag(0b10))
+    }
+}

--- a/app/src/androidTest/java/at/bitfire/icsdroid/TestSettings.kt
+++ b/app/src/androidTest/java/at/bitfire/icsdroid/TestSettings.kt
@@ -26,7 +26,7 @@ class TestSettings {
             settings.forceDarkModeFlow().collect { forceDarkMode = it }
         }
         // Set the preference to true
-        settings.forceDarkMode(true)
+        runBlocking { settings.forceDarkMode(true) }
         // Wait for the flow to update, or throw timeout
         runBlocking {
             withTimeout(1000) {

--- a/app/src/main/java/at/bitfire/icsdroid/DataStore.kt
+++ b/app/src/main/java/at/bitfire/icsdroid/DataStore.kt
@@ -1,0 +1,9 @@
+package at.bitfire.icsdroid
+
+import android.content.Context
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.preferencesDataStore
+
+// At the top level of your kotlin file:
+val Context.dataStore: DataStore<Preferences> by preferencesDataStore(name = "settings")

--- a/app/src/main/java/at/bitfire/icsdroid/Settings.kt
+++ b/app/src/main/java/at/bitfire/icsdroid/Settings.kt
@@ -5,18 +5,11 @@
 package at.bitfire.icsdroid
 
 import android.content.Context
-import android.content.SharedPreferences
 import androidx.datastore.preferences.core.booleanPreferencesKey
 import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.longPreferencesKey
-import androidx.lifecycle.LiveData
-import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.callbackFlow
-import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
-import kotlinx.coroutines.flow.single
-import kotlinx.coroutines.runBlocking
 
 class Settings(context: Context) {
 
@@ -24,19 +17,19 @@ class Settings(context: Context) {
         @Deprecated("Use DataStore")
         const val FORCE_DARK_MODE = "forceDarkMode"
 
-        val ForceDarkMode = booleanPreferencesKey("forceDarkMode")
+        val forceDarkMode = booleanPreferencesKey("forceDarkMode")
 
-        val PrefNextReminder = longPreferencesKey("nextDonationReminder")
+        val nextReminder = longPreferencesKey("nextDonationReminder")
     }
 
     private val dataStore = context.dataStore
 
 
-    fun forceDarkModeFlow(): Flow<Boolean> = dataStore.data.map { it[ForceDarkMode] ?: false }
+    fun forceDarkModeFlow(): Flow<Boolean> = dataStore.data.map { it[forceDarkMode] ?: false }
 
     suspend fun forceDarkMode(force: Boolean) {
         // save setting
-        dataStore.edit { it[ForceDarkMode] = force }
+        dataStore.edit { it[forceDarkMode] = force }
     }
 
 }

--- a/app/src/main/java/at/bitfire/icsdroid/Settings.kt
+++ b/app/src/main/java/at/bitfire/icsdroid/Settings.kt
@@ -6,44 +6,37 @@ package at.bitfire.icsdroid
 
 import android.content.Context
 import android.content.SharedPreferences
+import androidx.datastore.preferences.core.booleanPreferencesKey
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.longPreferencesKey
 import androidx.lifecycle.LiveData
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.callbackFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.single
+import kotlinx.coroutines.runBlocking
 
 class Settings(context: Context) {
 
     companion object {
-        private const val FORCE_DARK_MODE = "forceDarkMode"
+        @Deprecated("Use DataStore")
+        const val FORCE_DARK_MODE = "forceDarkMode"
+
+        val ForceDarkMode = booleanPreferencesKey("forceDarkMode")
+
+        val PrefNextReminder = longPreferencesKey("nextDonationReminder")
     }
 
+    private val dataStore = context.dataStore
 
-    private val prefs: SharedPreferences = context.getSharedPreferences("icsx5", 0)
 
-    fun forceDarkMode(): Boolean = prefs.getBoolean(FORCE_DARK_MODE, false)
+    fun forceDarkModeFlow(): Flow<Boolean> = dataStore.data.map { it[ForceDarkMode] ?: false }
 
-    fun forceDarkModeFlow(): Flow<Boolean> = callbackFlow {
-        val listener = SharedPreferences.OnSharedPreferenceChangeListener { prefs, key ->
-            if (key == FORCE_DARK_MODE) {
-                val forceDarkMode = prefs.getBoolean(key, false)
-                trySend(forceDarkMode)
-            }
-        }
-
-        prefs.registerOnSharedPreferenceChangeListener(listener)
-        listener.onSharedPreferenceChanged(prefs, FORCE_DARK_MODE)
-
-        awaitClose {
-            // Remove listener
-            prefs.unregisterOnSharedPreferenceChangeListener(listener)
-        }
-    }
-
-    fun forceDarkMode(force: Boolean) {
+    suspend fun forceDarkMode(force: Boolean) {
         // save setting
-        prefs.edit()
-            .putBoolean(FORCE_DARK_MODE, force)
-            .apply()
+        dataStore.edit { it[ForceDarkMode] = force }
     }
 
 }

--- a/app/src/main/java/at/bitfire/icsdroid/model/SubscriptionsModel.kt
+++ b/app/src/main/java/at/bitfire/icsdroid/model/SubscriptionsModel.kt
@@ -78,7 +78,7 @@ class SubscriptionsModel(application: Application): AndroidViewModel(application
         @Suppress("DEPRECATION")
         dataStore.edit {
             if (prefs.contains(Settings.FORCE_DARK_MODE)) {
-                it[Settings.ForceDarkMode] = prefs.getBoolean(Settings.FORCE_DARK_MODE, false)
+                it[Settings.forceDarkMode] = prefs.getBoolean(Settings.FORCE_DARK_MODE, false)
             }
         }
         // Clear everything

--- a/app/src/main/java/at/bitfire/icsdroid/service/ComposableStartupService.kt
+++ b/app/src/main/java/at/bitfire/icsdroid/service/ComposableStartupService.kt
@@ -16,12 +16,6 @@ import androidx.compose.runtime.State
  */
 interface ComposableStartupService {
     /**
-     * Will be called every time the main activity is created.
-     * @param activity The calling activity
-     */
-    fun initialize(activity: AppCompatActivity)
-
-    /**
      * Provides a stateful response to whether this composable should be shown or not.
      * @return A [State] that can be observed, and will make [Content] visible when `true`.
      */

--- a/app/src/main/java/at/bitfire/icsdroid/service/ComposableStartupService.kt
+++ b/app/src/main/java/at/bitfire/icsdroid/service/ComposableStartupService.kt
@@ -4,7 +4,6 @@
 
 package at.bitfire.icsdroid.service
 
-import androidx.appcompat.app.AppCompatActivity
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.State
 

--- a/app/src/main/java/at/bitfire/icsdroid/service/ComposableStartupService.kt
+++ b/app/src/main/java/at/bitfire/icsdroid/service/ComposableStartupService.kt
@@ -19,7 +19,7 @@ interface ComposableStartupService {
          * Tag services with this flag to tell the application that they are a donation dialog, and
          * they will be considered in `InfoActivity` to donate for example.
          */
-        const val FLAG_DONATION_DIALOG = 1
+        const val FLAG_DONATION_DIALOG = 0b1
     }
 
     val flags: Int

--- a/app/src/main/java/at/bitfire/icsdroid/service/ComposableStartupService.kt
+++ b/app/src/main/java/at/bitfire/icsdroid/service/ComposableStartupService.kt
@@ -22,6 +22,10 @@ interface ComposableStartupService {
         const val FLAG_DONATION_DIALOG = 0b1
     }
 
+    /**
+     * A bitwise flag that can be used to identify this service.
+     * Currently only [FLAG_DONATION_DIALOG] is supported.
+     */
     val flags: Int
 
     /**
@@ -37,4 +41,9 @@ interface ComposableStartupService {
      */
     @Composable
     fun Content()
+
+    /**
+     * Checks whether [flags] contains the given [flag] using bitwise operations.
+     */
+    fun hasFlag(flag: Int) = (flags and flag) == flag
 }

--- a/app/src/main/java/at/bitfire/icsdroid/service/ComposableStartupService.kt
+++ b/app/src/main/java/at/bitfire/icsdroid/service/ComposableStartupService.kt
@@ -15,6 +15,16 @@ import androidx.compose.runtime.State
  * is met.
  */
 interface ComposableStartupService {
+    companion object {
+        /**
+         * Tag services with this flag to tell the application that they are a donation dialog, and
+         * they will be considered in `InfoActivity` to donate for example.
+         */
+        const val FLAG_DONATION_DIALOG = 1
+    }
+
+    val flags: Int
+
     /**
      * Provides a stateful response to whether this composable should be shown or not.
      * @return A [State] that can be observed, and will make [Content] visible when `true`.

--- a/app/src/main/java/at/bitfire/icsdroid/ui/InfoActivity.kt
+++ b/app/src/main/java/at/bitfire/icsdroid/ui/InfoActivity.kt
@@ -51,6 +51,7 @@ import at.bitfire.icsdroid.R
 import at.bitfire.icsdroid.Settings.Companion.PrefNextReminder
 import at.bitfire.icsdroid.dataStore
 import at.bitfire.icsdroid.service.ComposableStartupService
+import at.bitfire.icsdroid.service.ComposableStartupService.Companion.FLAG_DONATION_DIALOG
 import at.bitfire.icsdroid.ui.partials.ExtendedTopAppBar
 import at.bitfire.icsdroid.ui.partials.GenericAlertDialog
 import at.bitfire.icsdroid.ui.theme.setContentThemed
@@ -72,7 +73,9 @@ class InfoActivity: AppCompatActivity() {
 
         // Init and collect all ComposableStartupServices
         val compStartupServices = ServiceLoader.load(ComposableStartupService::class.java)
-            .also { srv -> hasDonateDialogService = srv.any { it is DonateDialogService } }
+            .also { srv ->
+                hasDonateDialogService = srv.any { it.flags or FLAG_DONATION_DIALOG == FLAG_DONATION_DIALOG }
+            }
 
         setContentThemed {
             compStartupServices.forEach { service ->

--- a/app/src/main/java/at/bitfire/icsdroid/ui/InfoActivity.kt
+++ b/app/src/main/java/at/bitfire/icsdroid/ui/InfoActivity.kt
@@ -48,7 +48,7 @@ import androidx.datastore.preferences.core.edit
 import at.bitfire.icsdroid.BuildConfig
 import at.bitfire.icsdroid.Constants
 import at.bitfire.icsdroid.R
-import at.bitfire.icsdroid.Settings.Companion.PrefNextReminder
+import at.bitfire.icsdroid.Settings.Companion.nextReminder
 import at.bitfire.icsdroid.dataStore
 import at.bitfire.icsdroid.service.ComposableStartupService
 import at.bitfire.icsdroid.service.ComposableStartupService.Companion.FLAG_DONATION_DIALOG
@@ -227,7 +227,7 @@ class InfoActivity: AppCompatActivity() {
                 onClick = {
                     if (hasDonateDialogService) runBlocking {
                         // If there's a donate dialog service, show the dialog
-                        dataStore.edit { it[PrefNextReminder] = 0 }
+                        dataStore.edit { it[nextReminder] = 0 }
                     } else {
                         // If there's no service, show the donate dialog directly
                         showDonateDialog.value = true

--- a/app/src/main/java/at/bitfire/icsdroid/ui/InfoActivity.kt
+++ b/app/src/main/java/at/bitfire/icsdroid/ui/InfoActivity.kt
@@ -57,8 +57,8 @@ import at.bitfire.icsdroid.ui.partials.GenericAlertDialog
 import at.bitfire.icsdroid.ui.theme.setContentThemed
 import com.mikepenz.aboutlibraries.ui.compose.LibrariesContainer
 import com.mikepenz.aboutlibraries.ui.compose.LibraryDefaults
-import kotlinx.coroutines.runBlocking
 import java.util.ServiceLoader
+import kotlinx.coroutines.runBlocking
 
 class InfoActivity: AppCompatActivity() {
 
@@ -74,7 +74,7 @@ class InfoActivity: AppCompatActivity() {
         // Init and collect all ComposableStartupServices
         val compStartupServices = ServiceLoader.load(ComposableStartupService::class.java)
             .also { srv ->
-                hasDonateDialogService = srv.any { it.flags or FLAG_DONATION_DIALOG == FLAG_DONATION_DIALOG }
+                hasDonateDialogService = srv.any { it.flags and FLAG_DONATION_DIALOG == FLAG_DONATION_DIALOG }
             }
 
         setContentThemed {

--- a/app/src/main/java/at/bitfire/icsdroid/ui/InfoActivity.kt
+++ b/app/src/main/java/at/bitfire/icsdroid/ui/InfoActivity.kt
@@ -74,7 +74,7 @@ class InfoActivity: AppCompatActivity() {
         // Init and collect all ComposableStartupServices
         val compStartupServices = ServiceLoader.load(ComposableStartupService::class.java)
             .also { srv ->
-                hasDonateDialogService = srv.any { it.flags and FLAG_DONATION_DIALOG == FLAG_DONATION_DIALOG }
+                hasDonateDialogService = srv.any { it.hasFlag(FLAG_DONATION_DIALOG) }
             }
 
         setContentThemed {

--- a/app/src/main/java/at/bitfire/icsdroid/ui/screen/CalendarListScreen.kt
+++ b/app/src/main/java/at/bitfire/icsdroid/ui/screen/CalendarListScreen.kt
@@ -104,7 +104,7 @@ fun CalendarListScreen(
     onBatteryOptimizationWhitelist: () -> Unit = {},
     onAutoRevokePermission: () -> Unit = {},
     onSyncIntervalChange: (Long) -> Unit = {},
-    onToggleDarkMode: () -> Unit = {},
+    onToggleDarkMode: (forceDarkMode: Boolean) -> Unit = {},
     onAboutRequested: () -> Unit = {},
     onItemSelected: (Subscription) -> Unit = {}
 ) {
@@ -292,7 +292,7 @@ fun ActionOverflowMenu(
     forceDarkMode: Boolean,
     syncInterval: Long,
     onSyncIntervalChange: (Long) -> Unit = {},
-    onToggleDarkMode: () -> Unit = {},
+    onToggleDarkMode: (forceDarkMode: Boolean) -> Unit = {},
     onAboutRequested: () -> Unit = {},
     onRefreshRequested: () -> Unit = {}
 ) {
@@ -336,13 +336,13 @@ fun ActionOverflowMenu(
                     Text(stringResource(R.string.settings_force_dark_theme))
                     Checkbox(
                         checked = forceDarkMode,
-                        onCheckedChange = { onToggleDarkMode() }
+                        onCheckedChange = { onToggleDarkMode(!forceDarkMode) }
                     )
                 }
             },
             onClick =  {
                 showMenu = false
-                onToggleDarkMode()
+                onToggleDarkMode(!forceDarkMode)
             }
         )
         DropdownMenuItem(

--- a/app/src/main/java/at/bitfire/icsdroid/ui/views/CalendarListActivity.kt
+++ b/app/src/main/java/at/bitfire/icsdroid/ui/views/CalendarListActivity.kt
@@ -76,7 +76,6 @@ class CalendarListActivity: AppCompatActivity() {
 
         // Init and collect all ComposableStartupServices
         val compStartupServices = ServiceLoader.load(ComposableStartupService::class.java)
-            .onEach { it.initialize(this) }
 
         setContentThemed {
             compStartupServices.forEach { service ->

--- a/app/src/standard/java/at/bitfire/icsdroid/ui/DonateDialogService.kt
+++ b/app/src/standard/java/at/bitfire/icsdroid/ui/DonateDialogService.kt
@@ -15,7 +15,7 @@ import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.res.stringResource
 import androidx.datastore.preferences.core.edit
 import at.bitfire.icsdroid.R
-import at.bitfire.icsdroid.Settings.Companion.PrefNextReminder
+import at.bitfire.icsdroid.Settings.Companion.nextReminder
 import at.bitfire.icsdroid.dataStore
 import at.bitfire.icsdroid.service.ComposableStartupService
 import at.bitfire.icsdroid.service.ComposableStartupService.Companion.FLAG_DONATION_DIALOG
@@ -60,7 +60,7 @@ class DonateDialogService: ComposableStartupService {
     /**
      * Whether [Content] should be displayed or not.
      *
-     * Observes the value of the preference with key [PrefNextReminder] and sets its value to
+     * Observes the value of the preference with key [nextReminder] and sets its value to
      * *true* if the preference value lies in the past, or *false* otherwise.
      */
     @Composable
@@ -68,7 +68,7 @@ class DonateDialogService: ComposableStartupService {
         val context = LocalContext.current
         val dataStore = context.dataStore
         val flow = remember(dataStore) {
-            dataStore.data.map { (it[PrefNextReminder] ?: 0) < System.currentTimeMillis() }
+            dataStore.data.map { (it[nextReminder] ?: 0) < System.currentTimeMillis() }
         }
         return flow.collectAsState(initial = false)
     }
@@ -77,7 +77,7 @@ class DonateDialogService: ComposableStartupService {
      * Dismisses the dialog for the given amount of milliseconds by updating the preference.
      */
     private suspend fun dismissDialogForMillis(activity: AppCompatActivity, millis: Long) =
-        activity.dataStore.edit { it[PrefNextReminder] = System.currentTimeMillis() + millis }
+        activity.dataStore.edit { it[nextReminder] = System.currentTimeMillis() + millis }
 
     @Composable
     override fun Content() {

--- a/app/src/standard/java/at/bitfire/icsdroid/ui/DonateDialogService.kt
+++ b/app/src/standard/java/at/bitfire/icsdroid/ui/DonateDialogService.kt
@@ -9,6 +9,7 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.State
 import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.remember
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.res.stringResource
@@ -63,10 +64,14 @@ class DonateDialogService: ComposableStartupService {
      * *true* if the preference value lies in the past, or *false* otherwise.
      */
     @Composable
-    override fun shouldShow(): State<Boolean> = LocalContext.current.dataStore
-        .data
-        .map { (it[PrefNextReminder] ?: 0) < System.currentTimeMillis() }
-        .collectAsState(initial = false)
+    override fun shouldShow(): State<Boolean> {
+        val context = LocalContext.current
+        val dataStore = context.dataStore
+        val flow = remember(dataStore) {
+            dataStore.data.map { (it[PrefNextReminder] ?: 0) < System.currentTimeMillis() }
+        }
+        return flow.collectAsState(initial = false)
+    }
 
     /**
      * Dismisses the dialog for the given amount of milliseconds by updating the preference.

--- a/app/src/standard/java/at/bitfire/icsdroid/ui/DonateDialogService.kt
+++ b/app/src/standard/java/at/bitfire/icsdroid/ui/DonateDialogService.kt
@@ -13,7 +13,6 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.res.stringResource
 import androidx.datastore.preferences.core.edit
-import androidx.datastore.preferences.core.longPreferencesKey
 import at.bitfire.icsdroid.R
 import at.bitfire.icsdroid.Settings.Companion.PrefNextReminder
 import at.bitfire.icsdroid.dataStore

--- a/app/src/standard/java/at/bitfire/icsdroid/ui/DonateDialogService.kt
+++ b/app/src/standard/java/at/bitfire/icsdroid/ui/DonateDialogService.kt
@@ -18,6 +18,7 @@ import at.bitfire.icsdroid.R
 import at.bitfire.icsdroid.Settings.Companion.PrefNextReminder
 import at.bitfire.icsdroid.dataStore
 import at.bitfire.icsdroid.service.ComposableStartupService
+import at.bitfire.icsdroid.service.ComposableStartupService.Companion.FLAG_DONATION_DIALOG
 import at.bitfire.icsdroid.ui.partials.GenericAlertDialog
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -50,6 +51,8 @@ class DonateDialogService: ComposableStartupService {
          */
         const val SHOW_EVERY_MILLIS_DISMISS = ONE_DAY_MILLIS * 14
     }
+
+    override val flags: Int = FLAG_DONATION_DIALOG
 
     @Composable
     private fun getActivity(): AppCompatActivity? = LocalContext.current as? AppCompatActivity

--- a/app/src/standard/java/at/bitfire/icsdroid/ui/DonateDialogService.kt
+++ b/app/src/standard/java/at/bitfire/icsdroid/ui/DonateDialogService.kt
@@ -4,25 +4,28 @@
 
 package at.bitfire.icsdroid.ui
 
-import android.content.SharedPreferences
-import android.content.SharedPreferences.OnSharedPreferenceChangeListener
 import androidx.appcompat.app.AppCompatActivity
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.State
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
+import androidx.compose.runtime.collectAsState
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.res.stringResource
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.longPreferencesKey
 import at.bitfire.icsdroid.R
+import at.bitfire.icsdroid.Settings.Companion.PrefNextReminder
+import at.bitfire.icsdroid.dataStore
 import at.bitfire.icsdroid.service.ComposableStartupService
 import at.bitfire.icsdroid.ui.partials.GenericAlertDialog
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.launch
 
 class DonateDialogService: ComposableStartupService {
     companion object {
-        const val PREF_NEXT_REMINDER = "nextDonationReminder"
 
         const val DONATION_URI = "https://icsx5.bitfire.at/donate/?pk_campaign=icsx5-app"
 
@@ -48,55 +51,26 @@ class DonateDialogService: ComposableStartupService {
         const val SHOW_EVERY_MILLIS_DISMISS = ONE_DAY_MILLIS * 14
     }
 
-    private var preferences: SharedPreferences? = null
-
-    override fun initialize(activity: AppCompatActivity) {
-        if (preferences != null) return
-        preferences = getPreferences(activity)
-    }
-
-    // Note: Workaround for Android 6 (API 23) devices with low memory (1GB)
-    private fun getPreferences(activity: AppCompatActivity): SharedPreferences =
-        preferences ?: activity.getPreferences(0).also { preferences = it }
-
     @Composable
     private fun getActivity(): AppCompatActivity? = LocalContext.current as? AppCompatActivity
 
     /**
      * Whether [Content] should be displayed or not.
      *
-     * Observes the value of the preference with key [PREF_NEXT_REMINDER] and sets its value to
+     * Observes the value of the preference with key [PrefNextReminder] and sets its value to
      * *true* if the preference value lies in the past, or *false* otherwise.
      */
     @Composable
-    override fun shouldShow(): State<Boolean> = remember { mutableStateOf(false) }.also {
-        val activity = getActivity() ?: return@also
-        DisposableEffect(it) {
-            val listener = OnSharedPreferenceChangeListener { sharedPreferences, key ->
-                // Receive updates only for PREF_NEXT_REMINDER
-                if (key != PREF_NEXT_REMINDER) return@OnSharedPreferenceChangeListener
-                // Get preference value, calculate livedata value and post it
-                val nextReminderTime = sharedPreferences.getLong(PREF_NEXT_REMINDER, 0)
-                it.value = nextReminderTime < System.currentTimeMillis()
-            }
-            val preferences = getPreferences(activity)
-            preferences.registerOnSharedPreferenceChangeListener(listener)
-            listener.onSharedPreferenceChanged(preferences, PREF_NEXT_REMINDER)
-
-            onDispose {
-                preferences.unregisterOnSharedPreferenceChangeListener(listener)
-            }
-        }
-    }
+    override fun shouldShow(): State<Boolean> = LocalContext.current.dataStore
+        .data
+        .map { (it[PrefNextReminder] ?: 0) < System.currentTimeMillis() }
+        .collectAsState(initial = false)
 
     /**
      * Dismisses the dialog for the given amount of milliseconds by updating the preference.
      */
-    private fun dismissDialogForMillis(activity: AppCompatActivity, millis: Long) =
-        getPreferences(activity)
-            .edit()
-            .putLong(PREF_NEXT_REMINDER, System.currentTimeMillis() + millis)
-            .apply()
+    private suspend fun dismissDialogForMillis(activity: AppCompatActivity, millis: Long) =
+        activity.dataStore.edit { it[PrefNextReminder] = System.currentTimeMillis() + millis }
 
     @Composable
     override fun Content() {
@@ -107,11 +81,15 @@ class DonateDialogService: ComposableStartupService {
             title = stringResource(R.string.donate_title),
             content = { Text(stringResource(R.string.donate_message)) },
             confirmButton = Pair(stringResource(R.string.donate_now).uppercase()) {
-                dismissDialogForMillis(activity!!, SHOW_EVERY_MILLIS_DONATE)
+                CoroutineScope(Dispatchers.IO).launch {
+                    dismissDialogForMillis(activity!!, SHOW_EVERY_MILLIS_DONATE)
+                }
                 uriHandler.openUri(DONATION_URI)
             },
             dismissButton = Pair(stringResource(R.string.donate_later).uppercase()) {
-                dismissDialogForMillis(activity!!, SHOW_EVERY_MILLIS_DISMISS)
+                CoroutineScope(Dispatchers.IO).launch {
+                    dismissDialogForMillis(activity!!, SHOW_EVERY_MILLIS_DISMISS)
+                }
             }
         )
     }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -19,6 +19,7 @@ compose-material = "1.6.8"
 compose-material3 = "1.2.1"
 compose-runtime = "1.6.8"
 compose-ui = "1.6.8"
+datastore = "1.1.1"
 desugaring = "2.0.4"
 joda-time = "2.12.7"
 junit = "4.13.2"
@@ -34,6 +35,7 @@ androidx-activityCompose = { module = "androidx.activity:activity-compose", vers
 androidx-appCompat = { module = "androidx.appcompat:appcompat", version.ref = "androidx-appCompat" }
 androidx-arch-core-testing = { module = "androidx.arch.core:core-testing", version.ref = "androidx-archCore" }
 androidx-core = { module = "androidx.core:core-ktx", version.ref = "androidx-core" }
+androidx-datastore = { module = "androidx.datastore:datastore-preferences", version.ref = "datastore" }
 androidx-lifecycle-viewmodel = { module = "androidx.lifecycle:lifecycle-viewmodel-ktx", version.ref = "androidx-lifecycle" }
 androidx-lifecycle-viewmodel-compose = { module = "androidx.lifecycle:lifecycle-viewmodel-compose", version.ref = "androidx-lifecycle" }
 androidx-lifecycle-runtime-compose = { module = "androidx.lifecycle:lifecycle-runtime-compose", version.ref = "androidx-lifecycle" }


### PR DESCRIPTION
### Purpose

The ose version of ICSx5 shows a donation dialog every once in a while, which does have a correct working donation button, but once you hide it, it doesn't pop up again, and can't be invoked in any other way. If the one in the info activity is pressed, the same is shown both in gplay and standard, which doesn't contain any donation button to comply with Google Play's policy.

This dialog should be the same as the one that pops up automatically in standard.

### Short description

The preferences have been migrated to `DataStore` since otherwise there's no easy way to access them from outside the `DonateDialogService` for example.

There's a migration function in `SubscriptionsModel` even though I don't think it's even worth it for what it migrates.

Now in `InfoActivity` the services (`ComposableStartupService`) are also initialized. If there's a service with the `FLAG_DONATION_DIALOG` it's shown instead of the default "text dialog".

> [!NOTE]
> If we eventually migrate to Compose Navigation services won't be needed to be initialized twice since there would be only one Activity.

Maybe the migration to DataStore is not mandatory for this fix, but I think it's useful, and may solve any future issues.

### Checklist

- [x] The PR has a proper title, description and label.
- [x] I have [self-reviewed the PR](https://patrickdinh.medium.com/review-your-own-pull-requests-5634cad10b7a).
- [x] I have added documentation to complex functions and functions that can be used by other modules.
- [x] I have added reasonable tests or consciously decided to not add tests.
