### PR TITLE
Ignored warnings for unused classes

### DIFF
--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -10,6 +10,10 @@
 # ical4j: keep all iCalendar properties/parameters (used via reflection)
 -keep class net.fortuna.ical4j.** { *; }
 
+# we are not using those optional features of ical4j
+-dontwarn org.jparsec.** # parser for filter expressions
+-dontwarn javax.cache.** # timezone caching
+
 # we use enum classes (https://www.guardsquare.com/en/products/proguard/manual/examples#enumerations)
 -keepclassmembers,allowoptimization enum * {
     public static **[] values();
@@ -27,3 +31,8 @@
 -dontwarn org.joda.**
 -dontwarn org.json.*
 -dontwarn org.xmlpull.**
+
+# Seems to be incorrectly detected in https://github.com/ical4j/ical4j/blob/176fc84a4785d6f87be5dd18a20c6f83c6287b35/src/main/java/net/fortuna/ical4j/validate/schema/JsonSchemaValidator.java#L36C1-L36C39
+# Should be fixed eventually by ical4j
+# Commented in https://github.com/ical4j/ical4j/blob/176fc84a4785d6f87be5dd18a20c6f83c6287b35/build.gradle#L76
+-dontwarn com.github.erosb.jsonsKema.*


### PR DESCRIPTION
### Purpose

Fixed proguard warnings

### Short description

- Disabled warnings for `com.github.erosb.jsonsKema.*`, not used by anything, it looks that it's incorrectly being detected.
- Disabled warnings for `org.jparsec.**` and `javax.cache.**`. Optional features not used by ICSx⁵.

Maybe we should report the issue with `com.github.erosb.jsonsKema` in ical4j, even though since it has to do with proguard, maybe Ben doesn't want to do a release. What do you think @rfc2822 

### Checklist

- [x] The PR has a proper title, description and label.
- [x] I have [self-reviewed the PR](https://patrickdinh.medium.com/review-your-own-pull-requests-5634cad10b7a).
- [x] I have added documentation to complex functions and functions that can be used by other modules.
- [x] I have added reasonable tests or consciously decided to not add tests.
