### PR TITLE
Do not require internet connection for worker if only local subscriptions are used

### DIFF
--- a/app/src/main/java/at/bitfire/icsdroid/SyncAdapter.kt
+++ b/app/src/main/java/at/bitfire/icsdroid/SyncAdapter.kt
@@ -5,10 +5,15 @@
 package at.bitfire.icsdroid
 
 import android.accounts.Account
-import android.content.*
+import android.content.AbstractThreadedSyncAdapter
+import android.content.ContentProviderClient
+import android.content.ContentResolver
+import android.content.Context
+import android.content.SyncResult
 import android.os.Bundle
 import androidx.work.WorkManager
 import at.bitfire.icsdroid.ui.NotificationUtils
+import kotlinx.coroutines.runBlocking
 
 class SyncAdapter(
     context: Context
@@ -16,7 +21,7 @@ class SyncAdapter(
 
     override fun onPerformSync(account: Account, extras: Bundle, authority: String, provider: ContentProviderClient, syncResult: SyncResult) {
         val manual = extras.containsKey(ContentResolver.SYNC_EXTRAS_MANUAL)
-        SyncWorker.run(context, manual)
+        runBlocking { SyncWorker.run(context, manual) }
     }
 
     override fun onSyncCanceled(thread: Thread?) = onSyncCanceled()

--- a/app/src/main/java/at/bitfire/icsdroid/SyncWorker.kt
+++ b/app/src/main/java/at/bitfire/icsdroid/SyncWorker.kt
@@ -55,7 +55,7 @@ class SyncWorker(
                 val appDatabase = AppDatabase.getInstance(context)
                 appDatabase.subscriptionsDao()
                     .getAll()
-                    .any { it.url.scheme?.startsWith("http", true) == false }
+                    .all { it.url.scheme?.startsWith("http", true) == false }
             }
 
             val policy: ExistingWorkPolicy = if (force) {

--- a/app/src/main/java/at/bitfire/icsdroid/db/AppDatabase.kt
+++ b/app/src/main/java/at/bitfire/icsdroid/db/AppDatabase.kt
@@ -18,6 +18,7 @@ import at.bitfire.icsdroid.db.dao.CredentialsDao
 import at.bitfire.icsdroid.db.dao.SubscriptionsDao
 import at.bitfire.icsdroid.db.entity.Credential
 import at.bitfire.icsdroid.db.entity.Subscription
+import kotlinx.coroutines.runBlocking
 
 /**
  * The database for storing all the ICSx5 subscriptions and other data. Use [getInstance] for getting access to the database.
@@ -78,7 +79,7 @@ abstract class AppDatabase : RoomDatabase() {
                     .fallbackToDestructiveMigration()
                     .addCallback(object : Callback() {
                         override fun onCreate(db: SupportSQLiteDatabase) {
-                            SyncWorker.run(context, onlyMigrate = true)
+                            runBlocking { SyncWorker.run(context, onlyMigrate = true) }
                         }
                     })
                     .build()

--- a/app/src/main/java/at/bitfire/icsdroid/model/SubscriptionsModel.kt
+++ b/app/src/main/java/at/bitfire/icsdroid/model/SubscriptionsModel.kt
@@ -114,7 +114,7 @@ class SubscriptionsModel(application: Application): AndroidViewModel(application
         uiState = uiState.copy(askForAutoRevoke = !isAutoRevokeWhitelisted)
     }
 
-    fun onRefreshRequested() {
+    fun onRefreshRequested() = viewModelScope.launch(Dispatchers.IO) {
         SyncWorker.run(getApplication(), true)
     }
 

--- a/app/src/main/java/at/bitfire/icsdroid/ui/views/CalendarListActivity.kt
+++ b/app/src/main/java/at/bitfire/icsdroid/ui/views/CalendarListActivity.kt
@@ -13,7 +13,6 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import at.bitfire.icsdroid.PermissionUtils
-import at.bitfire.icsdroid.SyncWorker
 import at.bitfire.icsdroid.model.SubscriptionsModel
 import at.bitfire.icsdroid.service.ComposableStartupService
 import at.bitfire.icsdroid.ui.InfoActivity
@@ -60,8 +59,7 @@ class CalendarListActivity: AppCompatActivity() {
         // Register the calendar permission request
         requestCalendarPermissions = PermissionUtils.registerCalendarPermissionRequest(this) {
             model.checkSyncSettings()
-
-            SyncWorker.run(this)
+            model.onRefreshRequested()
         }
 
         // Register the notifications permission request


### PR DESCRIPTION
### Purpose

See #385, in some rare cases where INTERNET permission is not always granted, if trying to synchronize subscriptions for local files, they don't run since they wait until a network connection is available.

### Short description

Before running sync, all the subscriptions are fetched, and it's checked whether they are http urls. If all of them aren't, the internet connection requirement is not added. The requirement is also not added if only migrating.

### Checklist

- [x] The PR has a proper title, description and label.
- [x] I have [self-reviewed the PR](https://patrickdinh.medium.com/review-your-own-pull-requests-5634cad10b7a).
- [x] I have added documentation to complex functions and functions that can be used by other modules.
- [x] I have added reasonable tests or consciously decided to not add tests.
