### PR TITLE
Replaced deprecated gradle task

### DIFF
--- a/.github/workflows/test-dev.yml
+++ b/.github/workflows/test-dev.yml
@@ -40,7 +40,7 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: 17
-      - uses: gradle/gradle-build-action@v3
+      - uses: gradle/actions/setup-gradle@v4
 
       - name: Enable KVM group perms
         run: |


### PR DESCRIPTION
### Purpose

`gradle/gradle-build-action` was replaced by `gradle/actions/setup-gradle` and we were still missing this migration.

### Short description

Replaced `gradle/gradle-build-action@v3` by `gradle/actions/setup-gradle@v4`

### Checklist

- [x] The PR has a proper title, description and label.
- [x] I have [self-reviewed the PR](https://patrickdinh.medium.com/review-your-own-pull-requests-5634cad10b7a).
- [x] I have added documentation to complex functions and functions that can be used by other modules.
- [x] I have added reasonable tests or consciously decided to not add tests.
