### PR TITLE
Increase SDK to 35

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -10,14 +10,14 @@ plugins {
 }
 
 android {
-    compileSdk = 34
+    compileSdk = 35
 
     namespace = "at.bitfire.icsdroid"
 
     defaultConfig {
         applicationId = "at.bitfire.icsdroid"
         minSdk = 23
-        targetSdk = 34
+        targetSdk = 35
 
         versionCode = 80
         versionName = "2.2.4"


### PR DESCRIPTION

### Purpose

As discussed for DAVx⁵, increasing to 35 should not have any implications, just make sure to keep WorkManager up to date.

### Short description

Increased `compileSdk` and `targetSdk` to 35.

### Checklist

- [x] The PR has a proper title, description and label.
- [x] I have [self-reviewed the PR](https://patrickdinh.medium.com/review-your-own-pull-requests-5634cad10b7a).
- [x] I have added documentation to complex functions and functions that can be used by other modules.
- [x] I have added reasonable tests or consciously decided to not add tests.
