### PR TITLE
Set background color of items to transparent

### DIFF
--- a/app/src/main/java/at/bitfire/icsdroid/ui/partials/SyncIntervalDialog.kt
+++ b/app/src/main/java/at/bitfire/icsdroid/ui/partials/SyncIntervalDialog.kt
@@ -3,14 +3,16 @@ package at.bitfire.icsdroid.ui.partials
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
-import androidx.compose.material3.ListItem
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.RadioButtonChecked
 import androidx.compose.material.icons.filled.RadioButtonUnchecked
 import androidx.compose.material3.Icon
+import androidx.compose.material3.ListItem
+import androidx.compose.material3.ListItemDefaults
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringArrayResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
@@ -47,7 +49,10 @@ fun SyncIntervalDialog(
                                     Icons.Filled.RadioButtonUnchecked,
                                 contentDescription = null
                             )
-                        }
+                        },
+                        colors = ListItemDefaults.colors(
+                            containerColor = Color.Transparent
+                        )
                     )
                 }
             }


### PR DESCRIPTION
### Purpose

Regression in theme colors

### Short description

I think this is as simple as it can get. Simply disable the default background color of list items.

![image](https://github.com/user-attachments/assets/48603beb-1159-41d9-ba78-ca599f04bb2e)


### Checklist

- [x] The PR has a proper title, description and label.
- [x] I have [self-reviewed the PR](https://patrickdinh.medium.com/review-your-own-pull-requests-5634cad10b7a).
- [x] I have added documentation to complex functions and functions that can be used by other modules.
- [x] I have added reasonable tests or consciously decided to not add tests.
