### PR TITLE
Send setting value straight away

### DIFF
--- a/app/src/main/java/at/bitfire/icsdroid/model/SubscriptionsModel.kt
+++ b/app/src/main/java/at/bitfire/icsdroid/model/SubscriptionsModel.kt
@@ -59,7 +59,7 @@ class SubscriptionsModel(application: Application): AndroidViewModel(application
     val forceDarkMode = settings.forceDarkModeFlow()
         .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), false)
 
-    val syncInterval = AppAccount.syncIntervalFlow(application)
+    val syncInterval = AppAccount.getSyncIntervalFlow(application)
         .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), AppAccount.DEFAULT_SYNC_INTERVAL)
 
     init {
@@ -128,7 +128,7 @@ class SubscriptionsModel(application: Application): AndroidViewModel(application
     }
 
     fun onSyncIntervalChange(interval: Long) {
-        AppAccount.syncInterval(getApplication(), interval)
+        AppAccount.setSyncInterval(getApplication(), interval)
     }
 
     @SuppressLint("BatteryLife")


### PR DESCRIPTION
### Purpose

When collecting the sync interval setting flow the default value is emitted every time the app has a fresh start.

### Short description

Send a first setting value for sync interval flow straight away buffered, such that we have the settingsvalue available straight away. This seems to prevent the use of the default value which is otherwise used. 

### Checklist

- [X] The PR has a proper title, description and label.
- [X] I have [self-reviewed the PR](https://patrickdinh.medium.com/review-your-own-pull-requests-5634cad10b7a).
- [X] I have added documentation to complex functions and functions that can be used by other modules.
- [X] I have added reasonable tests or consciously decided to not add tests.
