### PR TITLE
Simplified edge-to-edge-configuration

### DIFF
--- a/app/src/main/java/at/bitfire/icsdroid/ui/theme/Theme.kt
+++ b/app/src/main/java/at/bitfire/icsdroid/ui/theme/Theme.kt
@@ -1,26 +1,15 @@
 package at.bitfire.icsdroid.ui.theme
 
-import android.util.Log
 import androidx.activity.ComponentActivity
-import androidx.activity.SystemBarStyle
 import androidx.activity.compose.setContent
-import androidx.activity.enableEdgeToEdge
-import androidx.appcompat.app.AppCompatActivity
 import androidx.compose.foundation.isSystemInDarkTheme
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.systemBarsPadding
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.darkColorScheme
 import androidx.compose.material3.lightColorScheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionContext
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
-import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.toArgb
-import androidx.compose.ui.platform.LocalContext
 import androidx.lifecycle.viewmodel.compose.viewModel
 import at.bitfire.icsdroid.model.ThemeModel
 
@@ -67,40 +56,10 @@ fun AppTheme(
     darkTheme: Boolean = isSystemInDarkTheme(),
     content: @Composable () -> Unit
 ) {
-    val context = LocalContext.current
-
-    val colorScheme = if (darkTheme)
-        DarkColors
-    else
-        LightColors
-
-    MaterialTheme(colorScheme = colorScheme) {
-        LaunchedEffect(darkTheme) {
-            (context as? AppCompatActivity)?.let { activity ->
-                val style = if (darkTheme)
-                    SystemBarStyle.dark(
-                        nearlyBlack.toArgb()
-                    )
-                else
-                    SystemBarStyle.dark(
-                        darkblue.toArgb()
-                    )
-                activity.enableEdgeToEdge(
-                    statusBarStyle = style,
-                    navigationBarStyle = style
-                )
-            } ?: Log.e("AppTheme", "Context is not activity!")
-        }
-
-        Box(
-            modifier = Modifier
-                // Required to make sure all paddings are correctly set
-                .systemBarsPadding()
-                .fillMaxSize()
-        ) {
-            content()
-        }
-    }
+    MaterialTheme(
+        colorScheme = if (darkTheme) DarkColors else LightColors,
+        content = content
+    )
 }
 
 /**

--- a/app/src/main/java/at/bitfire/icsdroid/ui/views/ActivityUtils.kt
+++ b/app/src/main/java/at/bitfire/icsdroid/ui/views/ActivityUtils.kt
@@ -1,0 +1,10 @@
+package at.bitfire.icsdroid.ui.views
+
+import androidx.activity.ComponentActivity
+import androidx.activity.enableEdgeToEdge
+import androidx.core.view.WindowCompat
+
+fun ComponentActivity.configureEdgeToEdge() {
+    enableEdgeToEdge()
+    WindowCompat.getInsetsController(window, window.decorView).isAppearanceLightStatusBars = false
+}

--- a/app/src/main/java/at/bitfire/icsdroid/ui/views/AddCalendarActivity.kt
+++ b/app/src/main/java/at/bitfire/icsdroid/ui/views/AddCalendarActivity.kt
@@ -9,20 +9,16 @@ import android.net.Uri
 import android.os.Bundle
 import android.os.Parcelable
 import android.provider.OpenableColumns
-import android.util.Log
 import android.widget.Toast
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
-import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.imePadding
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.platform.LocalContext
 import androidx.core.view.WindowCompat
-import at.bitfire.icsdroid.Constants
 import at.bitfire.icsdroid.HttpClient
 import at.bitfire.icsdroid.R
 import at.bitfire.icsdroid.UriUtils.stripUrl
@@ -32,11 +28,7 @@ import at.bitfire.icsdroid.model.CredentialsModel
 import at.bitfire.icsdroid.model.SubscriptionSettingsModel
 import at.bitfire.icsdroid.model.ValidationModel
 import at.bitfire.icsdroid.ui.screen.AddCalendarScreen
-import at.bitfire.icsdroid.ui.theme.lightblue
 import at.bitfire.icsdroid.ui.theme.setContentThemed
-import okhttp3.HttpUrl.Companion.toHttpUrl
-import java.net.URI
-import java.net.URISyntaxException
 
 class AddCalendarActivity : AppCompatActivity() {
 
@@ -71,6 +63,7 @@ class AddCalendarActivity : AppCompatActivity() {
         }
 
     override fun onCreate(savedInstanceState: Bundle?) {
+        configureEdgeToEdge()
         super.onCreate(savedInstanceState)
 
         WindowCompat.setDecorFitsSystemWindows(window, false)

--- a/app/src/main/java/at/bitfire/icsdroid/ui/views/CalendarListActivity.kt
+++ b/app/src/main/java/at/bitfire/icsdroid/ui/views/CalendarListActivity.kt
@@ -55,6 +55,7 @@ class CalendarListActivity: AppCompatActivity() {
 
 
     override fun onCreate(savedInstanceState: Bundle?) {
+        configureEdgeToEdge()
         super.onCreate(savedInstanceState)
 
         // Register the calendar permission request

--- a/app/src/main/java/at/bitfire/icsdroid/ui/views/EditCalendarActivity.kt
+++ b/app/src/main/java/at/bitfire/icsdroid/ui/views/EditCalendarActivity.kt
@@ -20,6 +20,7 @@ class EditCalendarActivity: AppCompatActivity() {
     }
 
     override fun onCreate(savedInstanceState: Bundle?) {
+        configureEdgeToEdge()
         super.onCreate(savedInstanceState)
         setContentThemed {
             EditCalendarScreen(


### PR DESCRIPTION
### Purpose

Fixes #490

### Short description

Simplified the whole edge-to-edge configuration. Now it's always "dark" for the status bar. Icons should always be white.

Skipped all the scrim thing because it just doesn't work well.

<details>
<summary>Light Mode</summary>

![light-mode](https://github.com/user-attachments/assets/ffb45ebf-b9e3-40d0-8933-9e5c1d0b605b)

</details>

<details>
<summary>Dark Mode</summary>

![dark-mode](https://github.com/user-attachments/assets/6297222d-565a-4ed2-b989-6bafb784c1ac)

</details>

### Checklist

- [x] The PR has a proper title, description and label.
- [x] I have [self-reviewed the PR](https://patrickdinh.medium.com/review-your-own-pull-requests-5634cad10b7a).
- [x] I have added documentation to complex functions and functions that can be used by other modules.
- [x] I have added reasonable tests or consciously decided to not add tests.
