### PR TITLE
Added more characters to url regex

### DIFF
--- a/app/src/main/java/at/bitfire/icsdroid/UriUtils.kt
+++ b/app/src/main/java/at/bitfire/icsdroid/UriUtils.kt
@@ -47,8 +47,8 @@ object UriUtils {
      * @throws IllegalArgumentException if no URL is found in the string
      */
     fun String.stripUrl(): String? {
-        //      schema             host          port         path           query
-        return ("([a-zA-Z]+://)" + "([\\w.]+)" + "(:\\d+)?" + "([\\w/]+)?" + "(\\?[\\w.&=*]*)?")
+        //      schema             host             port         path               query
+        return ("([a-zA-Z]+://)" + "([\\w\\-.]+)" + "(:\\d+)?" + "([\\w\\-./]+)?" + "(\\?[\\w.&=*]*)?")
             .toRegex()
             .find(this)
             ?.value

--- a/app/src/test/kotlin/at/bitfire/icsdroid/UrlUtilsTest.kt
+++ b/app/src/test/kotlin/at/bitfire/icsdroid/UrlUtilsTest.kt
@@ -7,8 +7,8 @@ import org.junit.Test
 class UrlUtilsTest {
     @Test
     fun testStripUrl() {
-        val url = "This is a URL: https://example.com/more/and/more?query=true.&par_am=test.more"
+        val url = "This is a URL: https://example-website.com/more/and/more-calendar.ics?query=true.&par_am=test.more"
         val strippedUrl = url.stripUrl()
-        assertEquals("https://example.com/more/and/more?query=true.&par_am=test.more", strippedUrl)
+        assertEquals("https://example-website.com/more/and/more-calendar.ics?query=true.&par_am=test.more", strippedUrl)
     }
 }


### PR DESCRIPTION
### Purpose

See #500. URLs are not being stripped correctly.

### Short description

Added more characters to the URL regex, and extended test in order to verify that more complex URLs work.

### Checklist

- [x] The PR has a proper title, description and label.
- [x] I have [self-reviewed the PR](https://patrickdinh.medium.com/review-your-own-pull-requests-5634cad10b7a).
- [x] I have added documentation to complex functions and functions that can be used by other modules.
- [x] I have added reasonable tests or consciously decided to not add tests.
