### PR TITLE
Bigger, scrollable URL subscription text field

### DIFF
--- a/app/src/main/java/at/bitfire/icsdroid/ui/views/EnterUrlComposable.kt
+++ b/app/src/main/java/at/bitfire/icsdroid/ui/views/EnterUrlComposable.kt
@@ -312,8 +312,7 @@ private fun ColumnScope.ResourceInput(
             imeAction = ImeAction.Go
         ),
         keyboardActions = KeyboardActions { onSubmit() },
-        maxLines = 1,
-        singleLine = true,
+        maxLines = 8,
         placeholder = { Text(labelText) },
         isError = error != null,
         interactionSource = remember { MutableInteractionSource() }.also { interactionSource ->
@@ -346,7 +345,9 @@ fun EnterUrlComposable_Preview() {
         password = "previewUserPassword",
         onPasswordChange = {},
         isInsecure = true,
-        url = "http://previewUrl.com/calendarfile.ics",
+        url = "http://previewUrl.com/looong/looong/looong/looong/looong/looong/calendarfile.ics" +
+            "\n\n a\n b\n c\n\n" +
+            "http://previewUrl.com/looong/looong/looong/looong/looong/looong/calendarfile.ics",
         fileName = "file name",
         onUrlChange = {},
         urlError = "",


### PR DESCRIPTION
### Purpose

Makes the URL subscription text field bigger and enables user to scroll forward and backward.

### Short description

- disable single line
- set maxLines to 8

For me that's enough to also be able to scroll the content of the text field

### Checklist

- [X] The PR has a proper title, description and label.
- [x] I have [self-reviewed the PR](https://patrickdinh.medium.com/review-your-own-pull-requests-5634cad10b7a).
- [x] I have added documentation to complex functions and functions that can be used by other modules.
- [x] I have added reasonable tests or consciously decided to not add tests.
