### PR TITLE
Replace `getParcelableExtra` usage with `IntentCompat`

### DIFF
--- a/app/src/main/java/at/bitfire/icsdroid/ui/views/AddCalendarActivity.kt
+++ b/app/src/main/java/at/bitfire/icsdroid/ui/views/AddCalendarActivity.kt
@@ -7,7 +7,6 @@ package at.bitfire.icsdroid.ui.views
 import android.content.Intent
 import android.net.Uri
 import android.os.Bundle
-import android.os.Parcelable
 import android.provider.OpenableColumns
 import android.widget.Toast
 import androidx.activity.result.contract.ActivityResultContracts
@@ -18,6 +17,7 @@ import androidx.compose.foundation.layout.imePadding
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
+import androidx.core.content.IntentCompat
 import androidx.core.view.WindowCompat
 import at.bitfire.icsdroid.HttpClient
 import at.bitfire.icsdroid.R
@@ -100,7 +100,7 @@ class AddCalendarActivity : AppCompatActivity() {
                             // Data does not have a valid url
                         }
 
-                        (intent.getParcelableExtra<Parcelable>(Intent.EXTRA_STREAM) as? Uri)
+                        IntentCompat.getParcelableExtra<Uri>(intent, Intent.EXTRA_STREAM, Uri::class.java)
                             ?.toString()
                             ?.let(subscriptionSettingsModel::setUrl)
                             ?.also {


### PR DESCRIPTION
### Purpose

Replace the deprecated method `Intent.getParcelableExtra` with the implementation from `IntentCompat`, which uses the most adequate method depending on the current API level.

### Short description

- Replace `Intent.getParcelableExtra` with `IntentCompat.getParcelableExtra`

### Checklist

- [x] The PR has a proper title, description and label.
- [x] I have [self-reviewed the PR](https://patrickdinh.medium.com/review-your-own-pull-requests-5634cad10b7a).
- [x] I have added documentation to complex functions and functions that can be used by other modules.
- [x] I have added reasonable tests or consciously decided to not add tests.
