### PR TITLE
Fix paddings for the enter url screen

### DIFF
--- a/app/src/main/java/at/bitfire/icsdroid/ui/views/EnterUrlComposable.kt
+++ b/app/src/main/java/at/bitfire/icsdroid/ui/views/EnterUrlComposable.kt
@@ -12,6 +12,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -22,9 +23,6 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.verticalScroll
-import androidx.compose.material3.SnackbarDuration
-import androidx.compose.material3.SnackbarHost
-import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.FolderOpen
 import androidx.compose.material.icons.filled.Link
@@ -33,6 +31,9 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SnackbarDuration
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Tab
 import androidx.compose.material3.TabRow
 import androidx.compose.material3.Text
@@ -102,7 +103,9 @@ fun EnterUrlComposable(
     }
 
     Scaffold(
-        snackbarHost = { SnackbarHost(snackbarHostState) }
+        snackbarHost = { SnackbarHost(snackbarHostState) },
+        // The WindowInsets are already applied on the Scaffold of AddCalendarScreen
+        contentWindowInsets = WindowInsets(0),
     ) { paddingValues ->
         Column(
             modifier = Modifier
@@ -117,10 +120,7 @@ fun EnterUrlComposable(
             val scope = rememberCoroutineScope()
             val state = rememberPagerState(pageCount = { 2 })
 
-            TabRow(
-                state.currentPage,
-                modifier = Modifier.padding(horizontal = 16.dp)
-            ) {
+            TabRow(state.currentPage) {
                 Tab(state.currentPage == 0, onClick = {
                     onUrlChange(null)
                     scope.launch { state.scrollToPage(0) }},


### PR DESCRIPTION
### Purpose

The paddings of the enter URL screen were not correct.

<details>
<summary>Screenshot</summary>

![image](https://github.com/user-attachments/assets/7ee1e2e4-57a1-4bb1-b4a5-df8e891e49b9)

</details>

This is caused because we are adding two scaffolds at the same time, the inner one only for showing a snackbar.

### Short description

- Disabled window insets for the innermost scaffold.
- Got rid of extra paddings for the tabs.

<details>
<summary>Screenshot</summary>

![image](https://github.com/user-attachments/assets/71170399-343a-40d3-8a5f-3635820c7f6f)

</details>

### Checklist

- [x] The PR has a proper title, description and label.
- [x] I have [self-reviewed the PR](https://patrickdinh.medium.com/review-your-own-pull-requests-5634cad10b7a).
- [x] I have added documentation to complex functions and functions that can be used by other modules.
- [x] I have added reasonable tests or consciously decided to not add tests.
