### PR TITLE
Fixed typo for IME action

### DIFF
--- a/app/src/main/java/at/bitfire/icsdroid/ui/screen/AddCalendarScreen.kt
+++ b/app/src/main/java/at/bitfire/icsdroid/ui/screen/AddCalendarScreen.kt
@@ -46,7 +46,6 @@ import at.bitfire.icsdroid.ui.views.SubscriptionSettingsComposable
 import kotlinx.coroutines.launch
 
 @Composable
-@OptIn(ExperimentalFoundationApi::class)
 fun AddCalendarScreen(
     createSubscriptionModel: CreateSubscriptionModel,
     subscriptionSettingsModel: SubscriptionSettingsModel,

--- a/app/src/main/java/at/bitfire/icsdroid/ui/screen/AddCalendarScreen.kt
+++ b/app/src/main/java/at/bitfire/icsdroid/ui/screen/AddCalendarScreen.kt
@@ -37,7 +37,6 @@ import at.bitfire.icsdroid.R
 import at.bitfire.icsdroid.model.CreateSubscriptionModel
 import at.bitfire.icsdroid.model.CredentialsModel
 import at.bitfire.icsdroid.model.SubscriptionSettingsModel
-import at.bitfire.icsdroid.model.SubscriptionsModel
 import at.bitfire.icsdroid.model.ValidationModel
 import at.bitfire.icsdroid.ui.ResourceInfo
 import at.bitfire.icsdroid.ui.partials.ExtendedTopAppBar
@@ -247,7 +246,7 @@ fun AddCalendarScreen(
                     validationResult = validationResult,
                     onValidationResultDismiss = onResetResult,
                     onPickFileRequested = onPickFileRequested,
-                    onSubmit = { onNextRequested(1) }
+                    onSubmit = { onNextRequested(0) }
                 )
 
                 1 -> SubscriptionSettingsComposable(


### PR DESCRIPTION
### Purpose

The IME "Go" button of the keyboard was doing nothing when entering a URL. This was because the index of the current page was incorrect.

### Short description

- Changed current index for moving into the next page to `0` instead of `1`.

### Checklist

- [x] The PR has a proper title, description and label.
- [x] I have [self-reviewed the PR](https://patrickdinh.medium.com/review-your-own-pull-requests-5634cad10b7a).
- [x] I have added documentation to complex functions and functions that can be used by other modules.
- [x] I have added reasonable tests or consciously decided to not add tests.
