### PR TITLE
Fix deprecations and issues with AboutLibs

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -163,6 +163,6 @@ dependencies {
 }
 
 aboutLibraries {
-    duplicationMode = DuplicateMode.MERGE
-    includePlatform = false
+    library.duplicationMode = DuplicateMode.MERGE
+    collect.includePlatform = false
 }

--- a/app/src/main/java/at/bitfire/icsdroid/ui/InfoActivity.kt
+++ b/app/src/main/java/at/bitfire/icsdroid/ui/InfoActivity.kt
@@ -55,11 +55,10 @@ import at.bitfire.icsdroid.service.ComposableStartupService.Companion.FLAG_DONAT
 import at.bitfire.icsdroid.ui.partials.ExtendedTopAppBar
 import at.bitfire.icsdroid.ui.partials.GenericAlertDialog
 import at.bitfire.icsdroid.ui.theme.setContentThemed
-import com.mikepenz.aboutlibraries.ui.compose.LibrariesContainer
-import com.mikepenz.aboutlibraries.ui.compose.LibraryDefaults
-import com.mikepenz.aboutlibraries.ui.compose.libraryColors
-import java.util.ServiceLoader
+import com.mikepenz.aboutlibraries.ui.compose.m3.LibrariesContainer
+import com.mikepenz.aboutlibraries.ui.compose.rememberLibraries
 import kotlinx.coroutines.runBlocking
+import java.util.ServiceLoader
 
 class InfoActivity: AppCompatActivity() {
 
@@ -144,16 +143,17 @@ class InfoActivity: AppCompatActivity() {
                 )
             }
         ) { contentPadding ->
+            val libraries by rememberLibraries {
+                resources.openRawResource(R.raw.aboutlibraries).bufferedReader().use { input ->
+                    input.readText()
+                }
+            }
+
             Column(Modifier.padding(contentPadding)) {
                 Header()
                 License()
                 LibrariesContainer(
-                    colors = LibraryDefaults.libraryColors(
-                        backgroundColor = MaterialTheme.colorScheme.background,
-                        contentColor = MaterialTheme.colorScheme.onBackground,
-                        badgeBackgroundColor = MaterialTheme.colorScheme.primary,
-                        badgeContentColor = MaterialTheme.colorScheme.onPrimary,
-                    )
+                    libraries = libraries
                 )
             }
         }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -28,7 +28,7 @@ okhttp = "4.12.0"
 room = "2.7.1"
 
 [libraries]
-aboutLibs-compose = { module = "com.mikepenz:aboutlibraries-compose", version.ref = "aboutLibs" }
+aboutLibs-compose = { module = "com.mikepenz:aboutlibraries-compose-m3", version.ref = "aboutLibs" }
 androidx-activityCompose = { module = "androidx.activity:activity-compose", version.ref = "androidx-activityCompose" }
 androidx-appCompat = { module = "androidx.appcompat:appcompat", version.ref = "androidx-appCompat" }
 androidx-arch-core-testing = { module = "androidx.arch.core:core-testing", version.ref = "androidx-archCore" }


### PR DESCRIPTION
### Purpose

There are some deprecations with aboutlibs. Also we should be using the M3 version.

### Short description

- Switched to M3
- Fixed usage of `LibrariesContainer` to the new non-deprecated method involving `rememberLibraries`.
- Replaced some deprecated usages in gradle.

### Checklist

- [x] The PR has a proper title, description and label.
- [x] I have [self-reviewed the PR](https://patrickdinh.medium.com/review-your-own-pull-requests-5634cad10b7a).
- [x] I have added documentation to complex functions and functions that can be used by other modules.
- [x] I have added reasonable tests or consciously decided to not add tests.
