### PR TITLE
Fixed deprecations

### DIFF
--- a/app/src/main/java/at/bitfire/icsdroid/AsyncUtils.kt
+++ b/app/src/main/java/at/bitfire/icsdroid/AsyncUtils.kt
@@ -26,7 +26,7 @@ suspend fun Call.executeAsync(): Response = suspendCancellableCoroutine { contin
         }
 
         override fun onResponse(call: Call, response: Response) {
-            continuation.resume(value = response, onCancellation = { call.cancel() })
+            continuation.resume(value = response, onCancellation = { _, _, _ -> call.cancel() })
         }
     })
 }

--- a/app/src/main/java/at/bitfire/icsdroid/ui/views/CalendarListActivity.kt
+++ b/app/src/main/java/at/bitfire/icsdroid/ui/views/CalendarListActivity.kt
@@ -12,6 +12,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.core.content.IntentCompat
 import at.bitfire.icsdroid.PermissionUtils
 import at.bitfire.icsdroid.SyncWorker
 import at.bitfire.icsdroid.model.SubscriptionsModel
@@ -20,6 +21,8 @@ import at.bitfire.icsdroid.ui.InfoActivity
 import at.bitfire.icsdroid.ui.partials.AlertDialog
 import at.bitfire.icsdroid.ui.screen.CalendarListScreen
 import at.bitfire.icsdroid.ui.theme.setContentThemed
+import at.bitfire.icsdroid.ui.views.CalendarListActivity.Companion.EXTRA_ERROR_MESSAGE
+import at.bitfire.icsdroid.ui.views.CalendarListActivity.Companion.EXTRA_THROWABLE
 import java.util.ServiceLoader
 
 class CalendarListActivity: AppCompatActivity() {
@@ -91,7 +94,7 @@ class CalendarListActivity: AppCompatActivity() {
             if (showingErrorMessage) {
                 AlertDialog(
                     intent.getStringExtra(EXTRA_ERROR_MESSAGE)!!,
-                    intent.getSerializableExtra(EXTRA_THROWABLE) as? Throwable
+                    IntentCompat.getSerializableExtra(intent, EXTRA_THROWABLE, Throwable::class.java)
                 ) { showingErrorMessage = false }
             }
 


### PR DESCRIPTION
### Purpose

Fixed two small deprecations.

### Short description

- Using the `CancellableContinuation.resume` overload that takes more arguments in `onCancellation`.
- Using `IntentCompat.getSerializableExtra` instead of the deprecated `Intent.getSerializableExtra`.

### Checklist

- [x] The PR has a proper title, description and label.
- [x] I have [self-reviewed the PR](https://patrickdinh.medium.com/review-your-own-pull-requests-5634cad10b7a).
- [x] I have added documentation to complex functions and functions that can be used by other modules.
- [x] I have added reasonable tests or consciously decided to not add tests.
