### PR TITLE
Increase connect timeout

### DIFF
--- a/app/src/main/java/at/bitfire/icsdroid/HttpClient.kt
+++ b/app/src/main/java/at/bitfire/icsdroid/HttpClient.kt
@@ -49,7 +49,7 @@ class HttpClient private constructor(
         .addNetworkInterceptor(BrotliInterceptor)
         .addNetworkInterceptor(UserAgentInterceptor)
         .followRedirects(false)
-        .connectTimeout(10, TimeUnit.SECONDS)
+        .connectTimeout(20, TimeUnit.SECONDS)
         .readTimeout(60, TimeUnit.SECONDS)
         .sslSocketFactory(sslContext.socketFactory, certManager)
         .hostnameVerifier(certManager.HostnameVerifier(OkHostnameVerifier))


### PR DESCRIPTION
Especially when working with Ical proxies, connections may take a little longer therefore I would suggest increasing the connect timeout.)


### Purpose

Increases the timeout for ical sync connections, as 10s is sometimes not sufficient, especially with ical proxies, many implementations of which download the backing ical feed completely, and then filter it before responding.

Currently I get a timeout in ~50% of syncs with my proxy (https://github.com/darkphnx/ical-filter-proxy/tree/master) backed by microsoft owa. 


### Checklist

- [X] The PR has a proper title, description and label.
- [X] I have [self-reviewed the PR](https://patrickdinh.medium.com/review-your-own-pull-requests-5634cad10b7a).
- [N/A] I have added documentation to complex functions and functions that can be used by other modules.
- [N/A] I have added reasonable tests or consciously decided to not add tests.
