### PR TITLE
Collect flow in viewModel only when needed

### DIFF
--- a/app/src/main/java/at/bitfire/icsdroid/db/dao/SubscriptionsDao.kt
+++ b/app/src/main/java/at/bitfire/icsdroid/db/dao/SubscriptionsDao.kt
@@ -1,7 +1,6 @@
 package at.bitfire.icsdroid.db.dao
 
 import android.net.Uri
-import androidx.lifecycle.LiveData
 import androidx.room.Dao
 import androidx.room.Delete
 import androidx.room.Embedded
@@ -31,6 +30,9 @@ interface SubscriptionsDao {
     @Query("SELECT * FROM subscriptions WHERE id=:id")
     suspend fun getById(id: Long): Subscription?
 
+    @Query("SELECT * FROM subscriptions WHERE id=:id")
+    fun getByIdFlow(id: Long): Flow<Subscription?>
+
     @Query("SELECT * FROM subscriptions WHERE calendarId=:calendarId")
     suspend fun getByCalendarId(calendarId: Long?): Subscription?
 
@@ -38,7 +40,7 @@ interface SubscriptionsDao {
     suspend fun getByUrl(url: String): Subscription?
 
     @Query("SELECT * FROM subscriptions WHERE id=:id")
-    fun getWithCredentialsByIdFlow(id: Long): Flow<SubscriptionWithCredential>
+    fun getWithCredentialsByIdFlow(id: Long): Flow<SubscriptionWithCredential?>
 
     @Query("SELECT errorMessage FROM subscriptions WHERE id=:id")
     fun getErrorMessageFlow(id: Long): Flow<String?>

--- a/app/src/main/java/at/bitfire/icsdroid/model/EditSubscriptionModel.kt
+++ b/app/src/main/java/at/bitfire/icsdroid/model/EditSubscriptionModel.kt
@@ -32,6 +32,7 @@ class EditSubscriptionModel(
     var uiState by mutableStateOf(UiState())
         private set
 
+    val subscription = db.subscriptionsDao().getByIdFlow(subscriptionId)
     val subscriptionWithCredential = db.subscriptionsDao().getWithCredentialsByIdFlow(subscriptionId)
 
     /**
@@ -42,12 +43,7 @@ class EditSubscriptionModel(
         credentialsModel: CredentialsModel
     ) {
         viewModelScope.launch(Dispatchers.IO) {
-            val subscriptionWithCredentials = db.subscriptionsDao()
-                .getWithCredentialsByIdFlow(subscriptionId)
-                .firstOrNull()
-
-            subscriptionWithCredentials?.let { subscriptionWithCredentials ->
-                val subscription = subscriptionWithCredentials.subscription
+            subscription.firstOrNull()?.let { subscription ->
                 val newSubscription = subscription.copy(
                     displayName = subscriptionSettingsModel.uiState.title ?: subscription.displayName,
                     color = subscriptionSettingsModel.uiState.color,
@@ -80,11 +76,8 @@ class EditSubscriptionModel(
      */
     fun removeSubscription() {
         viewModelScope.launch(Dispatchers.IO) {
-            val subscriptionWithCredentials = db.subscriptionsDao()
-                .getWithCredentialsByIdFlow(subscriptionId)
-                .firstOrNull()
-            subscriptionWithCredentials?.let { subscriptionWithCredentials ->
-                subscriptionsDao.delete(subscriptionWithCredentials.subscription)
+            subscription.firstOrNull()?.let { subscription ->
+                subscriptionsDao.delete(subscription)
 
                 // sync the subscription to reflect the changes in the calendar provider
                 SyncWorker.run(getApplication())

--- a/app/src/main/java/at/bitfire/icsdroid/model/EditSubscriptionModel.kt
+++ b/app/src/main/java/at/bitfire/icsdroid/model/EditSubscriptionModel.kt
@@ -1,12 +1,10 @@
 package at.bitfire.icsdroid.model
 
 import android.app.Application
-import android.content.Context
 import android.util.Log
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
-import androidx.core.app.ShareCompat
 import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.viewModelScope
 import at.bitfire.icsdroid.Constants
@@ -15,9 +13,7 @@ import at.bitfire.icsdroid.SyncWorker
 import at.bitfire.icsdroid.db.AppDatabase
 import at.bitfire.icsdroid.db.entity.Credential
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.firstOrNull
-import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 
 class EditSubscriptionModel(
@@ -37,7 +33,6 @@ class EditSubscriptionModel(
         private set
 
     val subscriptionWithCredential = db.subscriptionsDao().getWithCredentialsByIdFlow(subscriptionId)
-        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), null)
 
     /**
      * Updates the loaded subscription from the data provided by the view models.
@@ -47,9 +42,12 @@ class EditSubscriptionModel(
         credentialsModel: CredentialsModel
     ) {
         viewModelScope.launch(Dispatchers.IO) {
-            subscriptionWithCredential.value?.let { subscriptionWithCredentials ->
-                val subscription = subscriptionWithCredentials.subscription
+            val subscriptionWithCredentials = db.subscriptionsDao()
+                .getWithCredentialsByIdFlow(subscriptionId)
+                .firstOrNull()
 
+            subscriptionWithCredentials?.let { subscriptionWithCredentials ->
+                val subscription = subscriptionWithCredentials.subscription
                 val newSubscription = subscription.copy(
                     displayName = subscriptionSettingsModel.uiState.title ?: subscription.displayName,
                     color = subscriptionSettingsModel.uiState.color,
@@ -82,7 +80,10 @@ class EditSubscriptionModel(
      */
     fun removeSubscription() {
         viewModelScope.launch(Dispatchers.IO) {
-            subscriptionWithCredential.value?.let { subscriptionWithCredentials ->
+            val subscriptionWithCredentials = db.subscriptionsDao()
+                .getWithCredentialsByIdFlow(subscriptionId)
+                .firstOrNull()
+            subscriptionWithCredentials?.let { subscriptionWithCredentials ->
                 subscriptionsDao.delete(subscriptionWithCredentials.subscription)
 
                 // sync the subscription to reflect the changes in the calendar provider

--- a/app/src/main/java/at/bitfire/icsdroid/ui/screen/EditCalendarScreen.kt
+++ b/app/src/main/java/at/bitfire/icsdroid/ui/screen/EditCalendarScreen.kt
@@ -57,7 +57,7 @@ fun EditCalendarScreen(
     val editCalendarModel: EditCalendarModel = viewModel {
         EditCalendarModel(editSubscriptionModel, subscriptionSettingsModel, credentialsModel)
     }
-    val subscriptionWithCredentials = editSubscriptionModel.subscriptionWithCredential.collectAsStateWithLifecycle(null)
+    val subscription = editSubscriptionModel.subscription.collectAsStateWithLifecycle(null)
     EditCalendarScreen(
         inputValid = editCalendarModel.inputValid,
         modelsDirty = editCalendarModel.modelsDirty,
@@ -67,8 +67,8 @@ fun EditCalendarScreen(
             editSubscriptionModel.updateSubscription(subscriptionSettingsModel, credentialsModel)
         },
         onShare = {
-            subscriptionWithCredentials.value?.let {
-                onShare(it.subscription)
+            subscription.value?.let {
+                onShare(it)
             }
         },
         onExit = onExit,

--- a/app/src/main/java/at/bitfire/icsdroid/ui/screen/EditCalendarScreen.kt
+++ b/app/src/main/java/at/bitfire/icsdroid/ui/screen/EditCalendarScreen.kt
@@ -28,6 +28,7 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
 import at.bitfire.icsdroid.R
 import at.bitfire.icsdroid.db.entity.Subscription
@@ -56,6 +57,7 @@ fun EditCalendarScreen(
     val editCalendarModel: EditCalendarModel = viewModel {
         EditCalendarModel(editSubscriptionModel, subscriptionSettingsModel, credentialsModel)
     }
+    val subscriptionWithCredentials = editSubscriptionModel.subscriptionWithCredential.collectAsStateWithLifecycle(null)
     EditCalendarScreen(
         inputValid = editCalendarModel.inputValid,
         modelsDirty = editCalendarModel.modelsDirty,
@@ -65,7 +67,7 @@ fun EditCalendarScreen(
             editSubscriptionModel.updateSubscription(subscriptionSettingsModel, credentialsModel)
         },
         onShare = {
-            editSubscriptionModel.subscriptionWithCredential.value?.let {
+            subscriptionWithCredentials.value?.let {
                 onShare(it.subscription)
             }
         },


### PR DESCRIPTION
### Purpose

Collecting the flow only when needed, avoids continuous collection in the view model and might prevent the IllegalStateExceptions.

The proper way would be to avoid collecting the flow in the model at all, and only collect in the UI layer view, but that requires a bigger change, which we can do in a separate PR, if this does not fix the IllegalStateExceptions.

### Short description

- Collect the flow only when needed, avoiding continuous collection in the view model.
- Use .firstOrNull() to get the current value once inside the coroutine of updateSubscription and removeSubscriptoin.
- split subscription into a separate flow from subscriptionWithCredential for clarity

### Checklist

- [X] The PR has a proper title, description and label.
- [X] I have [self-reviewed the PR](https://patrickdinh.medium.com/review-your-own-pull-requests-5634cad10b7a).
- [X] I have added documentation to complex functions and functions that can be used by other modules.
- [X] I have added reasonable tests or consciously decided to not add tests.
