### PR TITLE
Use Hilt for DI

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -25,7 +25,7 @@ android {
 
         setProperty("archivesBaseName", "icsx5-$versionCode-$versionName")
 
-        testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
+        testInstrumentationRunner = "at.bitfire.icsdroid.HiltTestRunner"
 
         ksp {
             arg("room.schemaLocation", "$projectDir/schemas")

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -4,6 +4,7 @@ plugins {
     alias(libs.plugins.aboutLibs)
     alias(libs.plugins.android.application)
     alias(libs.plugins.compose.compiler)
+    alias(libs.plugins.hilt)
     alias(libs.plugins.kapt)
     alias(libs.plugins.kotlin)
     alias(libs.plugins.ksp)
@@ -122,6 +123,13 @@ dependencies {
     implementation(libs.compose.dialogs.color)
     implementation(libs.compose.dialogs.core)
 
+    // Hilt
+    implementation(libs.hilt.android.base)
+    ksp(libs.androidx.hilt.compiler)
+    ksp(libs.hilt.android.compiler)
+
+    implementation(libs.androidx.hilt.navigation.compose)
+    implementation(libs.androidx.hilt.work)
     implementation(libs.androidx.activityCompose)
     implementation(libs.androidx.appCompat)
     implementation(libs.androidx.core)
@@ -158,6 +166,7 @@ dependencies {
     androidTestImplementation(libs.junit)
     androidTestImplementation(libs.okhttp.mockwebserver)
     androidTestImplementation(libs.androidx.work.testing)
+    androidTestImplementation(libs.hilt.android.testing)
 
     testImplementation(libs.junit)
 }

--- a/app/src/androidTest/java/at/bitfire/icsdroid/BaseSyncWorkerTest.kt
+++ b/app/src/androidTest/java/at/bitfire/icsdroid/BaseSyncWorkerTest.kt
@@ -21,7 +21,6 @@ import at.bitfire.icsdroid.BaseSyncWorker.Companion.FORCE_RESYNC
 import at.bitfire.icsdroid.db.AppDatabase
 import at.bitfire.icsdroid.db.dao.SubscriptionsDao
 import at.bitfire.icsdroid.db.entity.Subscription
-import at.bitfire.icsdroid.test.BuildConfig
 import at.bitfire.icsdroid.test.R
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.cancel
@@ -68,8 +67,6 @@ class BaseSyncWorkerTest {
     fun prepareDatabase() {
         db = Room.inMemoryDatabaseBuilder(applicationContext, AppDatabase::class.java).build()
         subscriptionsDao = db.subscriptionsDao()
-
-        AppDatabase.setInstance(db)
     }
 
     @After
@@ -77,7 +74,6 @@ class BaseSyncWorkerTest {
     fun closeDatabase() {
         db.clearAllTables()
         db.close()
-        AppDatabase.setInstance(null)
     }
 
     private suspend fun runWorkerAndGetResult(): WorkInfo? {

--- a/app/src/androidTest/java/at/bitfire/icsdroid/BaseSyncWorkerTest.kt
+++ b/app/src/androidTest/java/at/bitfire/icsdroid/BaseSyncWorkerTest.kt
@@ -5,9 +5,7 @@ import android.content.ContentResolver
 import android.content.Context
 import android.net.Uri
 import android.util.Log
-import androidx.room.Room
-import androidx.test.core.app.ApplicationProvider
-import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.hilt.work.HiltWorkerFactory
 import androidx.test.rule.GrantPermissionRule
 import androidx.work.Configuration
 import androidx.work.OneTimeWorkRequestBuilder
@@ -19,9 +17,11 @@ import androidx.work.testing.WorkManagerTestInitHelper
 import androidx.work.workDataOf
 import at.bitfire.icsdroid.BaseSyncWorker.Companion.FORCE_RESYNC
 import at.bitfire.icsdroid.db.AppDatabase
-import at.bitfire.icsdroid.db.dao.SubscriptionsDao
 import at.bitfire.icsdroid.db.entity.Subscription
 import at.bitfire.icsdroid.test.R
+import dagger.hilt.android.qualifiers.ApplicationContext
+import dagger.hilt.android.testing.HiltAndroidRule
+import dagger.hilt.android.testing.HiltAndroidTest
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.filterNotNull
@@ -29,48 +29,45 @@ import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withTimeout
 import org.junit.After
 import org.junit.Before
-import org.junit.ClassRule
+import org.junit.Rule
 import org.junit.Test
-import org.junit.runner.RunWith
-import java.io.IOException
 import java.util.UUID
+import javax.inject.Inject
 
-@RunWith(AndroidJUnit4::class)
+@HiltAndroidTest
 class BaseSyncWorkerTest {
 
-    companion object {
-        @JvmField
-        @ClassRule
-        val calendarPermissionRule: GrantPermissionRule = GrantPermissionRule.grant(
-            Manifest.permission.READ_CALENDAR,
-            Manifest.permission.WRITE_CALENDAR,
-        )
-    }
-    private val applicationContext: Context get() = ApplicationProvider.getApplicationContext()
+    @Inject @ApplicationContext
+    lateinit var applicationContext: Context
 
-    /** Provides an in-memory interface to the app's database */
-    private lateinit var db: AppDatabase
-    private lateinit var subscriptionsDao: SubscriptionsDao
+    @Inject
+    lateinit var db: AppDatabase
 
-    // Initialize the test WorkManager for scheduling workers
+    @Inject
+    lateinit var workerFactory: HiltWorkerFactory
+
+    @get:Rule
+    val hiltRule = HiltAndroidRule(this)
+
+    @get:Rule
+    val calendarPermissionRule: GrantPermissionRule? = GrantPermissionRule.grant(
+        Manifest.permission.READ_CALENDAR, Manifest.permission.WRITE_CALENDAR
+    )
+
     @Before
-    fun prepareWorkManager() {
+    fun setUp() {
+        hiltRule.inject()
+
+        // Initialize the test WorkManager for scheduling workers
         val config = Configuration.Builder()
             .setMinimumLoggingLevel(Log.DEBUG)
+            .setWorkerFactory(workerFactory)
             .setExecutor(SynchronousExecutor())
             .build()
         WorkManagerTestInitHelper.initializeTestWorkManager(applicationContext, config)
     }
 
-    // Initialize the Room database
-    @Before
-    fun prepareDatabase() {
-        db = Room.inMemoryDatabaseBuilder(applicationContext, AppDatabase::class.java).build()
-        subscriptionsDao = db.subscriptionsDao()
-    }
-
     @After
-    @Throws(IOException::class)
     fun closeDatabase() {
         db.clearAllTables()
         db.close()
@@ -79,7 +76,7 @@ class BaseSyncWorkerTest {
     private suspend fun runWorkerAndGetResult(): WorkInfo? {
         // Run the worker
         val uuid = UUID.randomUUID()
-        val request = OneTimeWorkRequestBuilder<BaseSyncWorker>()
+        val request = OneTimeWorkRequestBuilder<TestSyncWorker>()
             .setId(uuid)
             .setInputData(workDataOf(FORCE_RESYNC to true))
             .build()
@@ -108,9 +105,9 @@ class BaseSyncWorkerTest {
     @Test
     fun syncSingleLocal() = runBlocking {
         // Insert a sample subscription
-        subscriptionsDao.add(
+        db.subscriptionsDao().add(
             Subscription(
-                url = Uri.parse("${ContentResolver.SCHEME_ANDROID_RESOURCE}://${BuildConfig.APPLICATION_ID}/${R.raw.sample}"),
+                url = Uri.parse("${ContentResolver.SCHEME_ANDROID_RESOURCE}://${BuildConfig.APPLICATION_ID}.test/${R.raw.sample}"),
                 displayName = "Local Subscription"
             )
         )
@@ -126,14 +123,14 @@ class BaseSyncWorkerTest {
     @Test
     fun syncLocalAndRemoteNotFound() = runBlocking {
         // Insert a local subscription (success)
-        subscriptionsDao.add(
+        db.subscriptionsDao().add(
             Subscription(
-                url = Uri.parse("${ContentResolver.SCHEME_ANDROID_RESOURCE}://${BuildConfig.APPLICATION_ID}/${R.raw.sample}"),
+                url = Uri.parse("${ContentResolver.SCHEME_ANDROID_RESOURCE}://${BuildConfig.APPLICATION_ID}.test/${R.raw.sample}"),
                 displayName = "Local Subscription"
             )
         )
         // Insert a remote subscription that doesn't exist (failure)
-        subscriptionsDao.add(
+        db.subscriptionsDao().add(
             Subscription(
                 url = Uri.parse("https://example.com/invalid.ics"),
                 displayName = "Remote Subscription"

--- a/app/src/androidTest/java/at/bitfire/icsdroid/HiltTestRunner.kt
+++ b/app/src/androidTest/java/at/bitfire/icsdroid/HiltTestRunner.kt
@@ -1,0 +1,18 @@
+/*
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
+ */
+
+package at.bitfire.icsdroid
+
+import android.app.Application
+import android.content.Context
+import androidx.test.runner.AndroidJUnitRunner
+import dagger.hilt.android.testing.HiltTestApplication
+
+@Suppress("unused")
+class HiltTestRunner : AndroidJUnitRunner() {
+
+    override fun newApplication(cl: ClassLoader, name: String, context: Context): Application =
+        super.newApplication(cl, HiltTestApplication::class.java.name, context)
+
+}

--- a/app/src/androidTest/java/at/bitfire/icsdroid/TestSyncWorker.kt
+++ b/app/src/androidTest/java/at/bitfire/icsdroid/TestSyncWorker.kt
@@ -1,0 +1,11 @@
+package at.bitfire.icsdroid
+
+import androidx.hilt.work.HiltWorker
+import dagger.assisted.Assisted
+import dagger.assisted.AssistedInject
+
+@HiltWorker
+class TestSyncWorker @AssistedInject constructor(
+    @Assisted appContext: android.content.Context,
+    @Assisted workerParams: androidx.work.WorkerParameters
+) : BaseSyncWorker(appContext, workerParams)

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -37,6 +37,7 @@
     <uses-permission android:name="at.techbee.jtx.permission.WRITE" tools:node="remove" />
 
     <application
+        android:name="at.bitfire.icsdroid.App"
         android:allowBackup="true"
         android:fullBackupOnly="true"
         android:fullBackupContent="@xml/backup_rules"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -37,7 +37,7 @@
     <uses-permission android:name="at.techbee.jtx.permission.WRITE" tools:node="remove" />
 
     <application
-        android:name="at.bitfire.icsdroid.App"
+        android:name=".App"
         android:allowBackup="true"
         android:fullBackupOnly="true"
         android:fullBackupContent="@xml/backup_rules"
@@ -48,6 +48,13 @@
         android:theme="@style/Theme.AppCompat.DayNight.NoActionBar"
         android:enableOnBackInvokedCallback="true"
         tools:ignore="UnusedAttribute">
+
+        <!-- required for Hilt/WorkManager integration -->
+        <provider
+            android:name="androidx.startup.InitializationProvider"
+            android:authorities="${applicationId}.androidx-startup"
+            tools:node="remove">
+        </provider>
 
         <service
             android:name=".AccountAuthenticatorService"

--- a/app/src/main/java/at/bitfire/icsdroid/App.kt
+++ b/app/src/main/java/at/bitfire/icsdroid/App.kt
@@ -1,7 +1,20 @@
 package at.bitfire.icsdroid
 
 import android.app.Application
+import androidx.hilt.work.HiltWorkerFactory
+import androidx.work.Configuration
 import dagger.hilt.android.HiltAndroidApp
+import javax.inject.Inject
 
 @HiltAndroidApp
-class App: Application()
+class App : Application(), Configuration.Provider {
+
+    @Inject
+    lateinit var workerFactory: HiltWorkerFactory
+
+    override val workManagerConfiguration: Configuration
+        get() = Configuration.Builder()
+            .setWorkerFactory(workerFactory)
+            .build()
+
+}

--- a/app/src/main/java/at/bitfire/icsdroid/App.kt
+++ b/app/src/main/java/at/bitfire/icsdroid/App.kt
@@ -1,0 +1,7 @@
+package at.bitfire.icsdroid
+
+import android.app.Application
+import dagger.hilt.android.HiltAndroidApp
+
+@HiltAndroidApp
+class App: Application()

--- a/app/src/main/java/at/bitfire/icsdroid/PeriodicSyncWorker.kt
+++ b/app/src/main/java/at/bitfire/icsdroid/PeriodicSyncWorker.kt
@@ -5,17 +5,21 @@
 package at.bitfire.icsdroid
 
 import android.content.Context
+import androidx.hilt.work.HiltWorker
 import androidx.work.Constraints
 import androidx.work.ExistingPeriodicWorkPolicy
 import androidx.work.NetworkType
 import androidx.work.PeriodicWorkRequestBuilder
 import androidx.work.WorkManager
 import androidx.work.WorkerParameters
+import dagger.assisted.Assisted
+import dagger.assisted.AssistedInject
 import java.time.Duration
 
-class PeriodicSyncWorker(
-    context: Context,
-    workerParams: WorkerParameters
+@HiltWorker
+class PeriodicSyncWorker @AssistedInject constructor(
+    @Assisted context: Context,
+    @Assisted workerParams: WorkerParameters
 ): BaseSyncWorker(context, workerParams) {
 
     companion object {

--- a/app/src/main/java/at/bitfire/icsdroid/SyncWorker.kt
+++ b/app/src/main/java/at/bitfire/icsdroid/SyncWorker.kt
@@ -6,6 +6,7 @@ package at.bitfire.icsdroid
 
 import android.content.Context
 import android.util.Log
+import androidx.hilt.work.HiltWorker
 import androidx.work.Constraints
 import androidx.work.ExistingWorkPolicy
 import androidx.work.NetworkType
@@ -14,10 +15,13 @@ import androidx.work.WorkManager
 import androidx.work.WorkerParameters
 import androidx.work.workDataOf
 import at.bitfire.icsdroid.Constants.TAG
+import dagger.assisted.Assisted
+import dagger.assisted.AssistedInject
 
-class SyncWorker(
-    context: Context,
-    workerParams: WorkerParameters
+@HiltWorker
+class SyncWorker @AssistedInject constructor(
+    @Assisted context: Context,
+    @Assisted workerParams: WorkerParameters,
 ) : BaseSyncWorker(context, workerParams) {
 
     companion object {

--- a/app/src/main/java/at/bitfire/icsdroid/db/AppDatabase.kt
+++ b/app/src/main/java/at/bitfire/icsdroid/db/AppDatabase.kt
@@ -5,7 +5,6 @@
 package at.bitfire.icsdroid.db
 
 import android.content.Context
-import androidx.annotation.VisibleForTesting
 import androidx.room.AutoMigration
 import androidx.room.Database
 import androidx.room.Room
@@ -13,14 +12,19 @@ import androidx.room.RoomDatabase
 import androidx.room.TypeConverters
 import androidx.sqlite.db.SupportSQLiteDatabase
 import at.bitfire.icsdroid.SyncWorker
-import at.bitfire.icsdroid.db.AppDatabase.Companion.getInstance
 import at.bitfire.icsdroid.db.dao.CredentialsDao
 import at.bitfire.icsdroid.db.dao.SubscriptionsDao
 import at.bitfire.icsdroid.db.entity.Credential
 import at.bitfire.icsdroid.db.entity.Subscription
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.android.qualifiers.ApplicationContext
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
 
 /**
- * The database for storing all the ICSx5 subscriptions and other data. Use [getInstance] for getting access to the database.
+ * The database for storing all the ICSx5 subscriptions and other data.
  */
 @TypeConverters(Converters::class)
 @Database(
@@ -43,49 +47,24 @@ import at.bitfire.icsdroid.db.entity.Subscription
 )
 abstract class AppDatabase : RoomDatabase() {
 
-    companion object {
-        @Volatile
-        private var instance: AppDatabase? = null
+    @Module
+    @InstallIn(SingletonComponent::class)
+    object AppDatabaseModule {
 
-        /**
-         * This function is only intended to be used by tests, use [getInstance], it initializes
-         * the instance automatically.
-         */
-        @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
-        fun setInstance(instance: AppDatabase?) {
-            this.instance = instance
-        }
-
-        /**
-         * Gets or instantiates the database singleton. Thread-safe.
-         * @param context The application's context, required to create the database.
-         */
-        fun getInstance(context: Context): AppDatabase {
-            // if we have an existing instance, return it
-            instance?.let {
-                return it
-            }
-
-            // multiple threads might access this code at once, so synchronize it
-            synchronized(AppDatabase) {
-                // another thread might just have created an instance
-                instance?.let {
-                    return it
+        @Provides
+        @Singleton
+        fun provideAppDatabase(
+            @ApplicationContext context: Context
+        ): AppDatabase = Room
+            .databaseBuilder(context, AppDatabase::class.java, "icsx5.db")
+            .fallbackToDestructiveMigration(true)
+            .addCallback(object : Callback() {
+                override fun onCreate(db: SupportSQLiteDatabase) {
+                    SyncWorker.run(context)
                 }
+            })
+            .build()
 
-                // create a new instance and save it
-                val db = Room.databaseBuilder(context.applicationContext, AppDatabase::class.java, "icsx5")
-                    .fallbackToDestructiveMigration()
-                    .addCallback(object : Callback() {
-                        override fun onCreate(db: SupportSQLiteDatabase) {
-                            SyncWorker.run(context)
-                        }
-                    })
-                    .build()
-                instance = db
-                return db
-            }
-        }
     }
 
     abstract fun subscriptionsDao(): SubscriptionsDao

--- a/app/src/main/java/at/bitfire/icsdroid/db/AppDatabase.kt
+++ b/app/src/main/java/at/bitfire/icsdroid/db/AppDatabase.kt
@@ -56,7 +56,7 @@ abstract class AppDatabase : RoomDatabase() {
         fun provideAppDatabase(
             @ApplicationContext context: Context
         ): AppDatabase = Room
-            .databaseBuilder(context, AppDatabase::class.java, "icsx5.db")
+            .databaseBuilder(context, AppDatabase::class.java, "icsx5")
             .fallbackToDestructiveMigration(true)
             .addCallback(object : Callback() {
                 override fun onCreate(db: SupportSQLiteDatabase) {

--- a/app/src/main/java/at/bitfire/icsdroid/model/CredentialsModel.kt
+++ b/app/src/main/java/at/bitfire/icsdroid/model/CredentialsModel.kt
@@ -5,9 +5,11 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import androidx.lifecycle.ViewModel
 import at.bitfire.icsdroid.db.entity.Credential
-import kotlinx.coroutines.flow.MutableStateFlow
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
 
-class CredentialsModel : ViewModel() {
+@HiltViewModel
+class CredentialsModel @Inject constructor(): ViewModel() {
     data class UiState(
         val requiresAuth: Boolean = false,
         val username: String? = null,

--- a/app/src/main/java/at/bitfire/icsdroid/model/EditSubscriptionModel.kt
+++ b/app/src/main/java/at/bitfire/icsdroid/model/EditSubscriptionModel.kt
@@ -12,6 +12,10 @@ import at.bitfire.icsdroid.R
 import at.bitfire.icsdroid.SyncWorker
 import at.bitfire.icsdroid.db.AppDatabase
 import at.bitfire.icsdroid.db.entity.Credential
+import dagger.hilt.EntryPoint
+import dagger.hilt.InstallIn
+import dagger.hilt.android.EntryPointAccessors
+import dagger.hilt.components.SingletonComponent
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.launch
@@ -21,7 +25,14 @@ class EditSubscriptionModel(
     private val subscriptionId: Long
 ): AndroidViewModel(application) {
 
-    private val db = AppDatabase.getInstance(application)
+    @EntryPoint
+    @InstallIn(SingletonComponent::class)
+    interface EditSubscriptionModelEntryPoint {
+        fun appDatabase(): AppDatabase
+    }
+
+    val db = EntryPointAccessors.fromApplication(application, EditSubscriptionModelEntryPoint::class.java).appDatabase()
+
     private val credentialsDao = db.credentialsDao()
     private val subscriptionsDao = db.subscriptionsDao()
 

--- a/app/src/main/java/at/bitfire/icsdroid/model/SubscriptionSettingsModel.kt
+++ b/app/src/main/java/at/bitfire/icsdroid/model/SubscriptionSettingsModel.kt
@@ -5,17 +5,14 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import androidx.lifecycle.ViewModel
-import androidx.lifecycle.viewModelScope
 import at.bitfire.icsdroid.HttpUtils
 import at.bitfire.icsdroid.db.entity.Subscription
-import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.SharingStarted
-import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.map
-import kotlinx.coroutines.flow.stateIn
+import dagger.hilt.android.lifecycle.HiltViewModel
 import java.net.URISyntaxException
+import javax.inject.Inject
 
-class SubscriptionSettingsModel : ViewModel() {
+@HiltViewModel
+class SubscriptionSettingsModel @Inject constructor() : ViewModel() {
     data class UiState(
         val url: String? = null,
         val fileName: String? = null,

--- a/app/src/main/java/at/bitfire/icsdroid/model/SubscriptionsModel.kt
+++ b/app/src/main/java/at/bitfire/icsdroid/model/SubscriptionsModel.kt
@@ -147,17 +147,16 @@ class SubscriptionsModel @Inject constructor(
 
     @SuppressLint("BatteryLife")
     fun onBatteryOptimizationWhitelist() {
-        val ctx = context
         val intent = Intent()
-        val pm : PowerManager = ctx.getSystemService(Context.POWER_SERVICE) as PowerManager
-        if (pm.isIgnoringBatteryOptimizations(ctx.packageName)) {
+        val pm : PowerManager = context.getSystemService(Context.POWER_SERVICE) as PowerManager
+        if (pm.isIgnoringBatteryOptimizations(context.packageName)) {
             intent.action = android.provider.Settings.ACTION_IGNORE_BATTERY_OPTIMIZATION_SETTINGS
         } else {
             intent.action = android.provider.Settings.ACTION_REQUEST_IGNORE_BATTERY_OPTIMIZATIONS
-            intent.data = Uri.parse("package:${ctx.packageName}")
+            intent.data = Uri.parse("package:${context.packageName}")
         }
         intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
-        ctx.startActivity(intent)
+        context.startActivity(intent)
     }
 
     @SuppressLint("InlinedApi")

--- a/app/src/main/java/at/bitfire/icsdroid/model/ThemeModel.kt
+++ b/app/src/main/java/at/bitfire/icsdroid/model/ThemeModel.kt
@@ -1,14 +1,20 @@
 package at.bitfire.icsdroid.model
 
-import android.app.Application
-import androidx.lifecycle.AndroidViewModel
+import android.content.Context
+import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import at.bitfire.icsdroid.Settings
+import dagger.hilt.android.lifecycle.HiltViewModel
+import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.stateIn
+import javax.inject.Inject
 
-class ThemeModel(application: Application) : AndroidViewModel(application) {
-    private val settings = Settings(application)
+@HiltViewModel
+class ThemeModel @Inject constructor(
+    @ApplicationContext context: Context
+) : ViewModel() {
+    private val settings = Settings(context)
 
     val forceDarkMode = settings.forceDarkModeFlow()
         .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), false)

--- a/app/src/main/java/at/bitfire/icsdroid/model/ValidationModel.kt
+++ b/app/src/main/java/at/bitfire/icsdroid/model/ValidationModel.kt
@@ -4,13 +4,13 @@
 
 package at.bitfire.icsdroid.model
 
-import android.app.Application
+import android.content.Context
 import android.net.Uri
 import android.util.Log
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
-import androidx.lifecycle.AndroidViewModel
+import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import at.bitfire.ical4android.Css3Color
 import at.bitfire.ical4android.Event
@@ -20,14 +20,20 @@ import at.bitfire.icsdroid.Constants
 import at.bitfire.icsdroid.HttpUtils.toURI
 import at.bitfire.icsdroid.HttpUtils.toUri
 import at.bitfire.icsdroid.ui.ResourceInfo
+import dagger.hilt.android.lifecycle.HiltViewModel
+import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import net.fortuna.ical4j.model.property.Color
 import okhttp3.MediaType
 import java.io.InputStream
 import java.io.InputStreamReader
+import javax.inject.Inject
 
-class ValidationModel(application: Application): AndroidViewModel(application) {
+@HiltViewModel
+class ValidationModel @Inject constructor(
+    @ApplicationContext private val context: Context,
+): ViewModel() {
 
     data class UiState(
         val isVerifyingUrl: Boolean = false,
@@ -52,7 +58,7 @@ class ValidationModel(application: Application): AndroidViewModel(application) {
             uiState = uiState.copy(isVerifyingUrl = true)
 
             val info = ResourceInfo(originalUri)
-            val downloader = object: CalendarFetcher(getApplication(), originalUri) {
+            val downloader = object: CalendarFetcher(context, originalUri) {
                 override suspend fun onSuccess(
                     data: InputStream,
                     contentType: MediaType?,

--- a/app/src/main/java/at/bitfire/icsdroid/ui/screen/EditCalendarScreen.kt
+++ b/app/src/main/java/at/bitfire/icsdroid/ui/screen/EditCalendarScreen.kt
@@ -28,6 +28,7 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
 import at.bitfire.icsdroid.R
@@ -44,15 +45,15 @@ import at.bitfire.icsdroid.ui.views.SubscriptionSettingsComposable
 
 @Composable
 fun EditCalendarScreen(
-    application: Application,
     subscriptionId: Long,
     onShare: (subscription: Subscription) -> Unit,
     onExit: () -> Unit = {}
 ) {
-    val credentialsModel: CredentialsModel = viewModel()
-    val subscriptionSettingsModel: SubscriptionSettingsModel = viewModel()
+    val applicationContext = LocalContext.current.applicationContext
+    val credentialsModel: CredentialsModel = hiltViewModel()
+    val subscriptionSettingsModel: SubscriptionSettingsModel = hiltViewModel()
     val editSubscriptionModel: EditSubscriptionModel = viewModel {
-        EditSubscriptionModel(application, subscriptionId)
+        EditSubscriptionModel(applicationContext as Application, subscriptionId)
     }
     val editCalendarModel: EditCalendarModel = viewModel {
         EditCalendarModel(editSubscriptionModel, subscriptionSettingsModel, credentialsModel)

--- a/app/src/main/java/at/bitfire/icsdroid/ui/theme/Theme.kt
+++ b/app/src/main/java/at/bitfire/icsdroid/ui/theme/Theme.kt
@@ -10,7 +10,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionContext
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
-import androidx.lifecycle.viewmodel.compose.viewModel
+import androidx.hilt.navigation.compose.hiltViewModel
 import at.bitfire.icsdroid.model.ThemeModel
 
 private val DarkColors = darkColorScheme(
@@ -85,7 +85,7 @@ fun AppTheme(
 fun ComponentActivity.setContentThemed(
     parent: CompositionContext? = null,
     darkTheme: @Composable () -> Boolean = {
-        val model = viewModel<ThemeModel>()
+        val model = hiltViewModel<ThemeModel>()
         val forceDarkTheme by model.forceDarkMode.collectAsState()
         forceDarkTheme || isSystemInDarkTheme()
     },

--- a/app/src/main/java/at/bitfire/icsdroid/ui/views/AddCalendarActivity.kt
+++ b/app/src/main/java/at/bitfire/icsdroid/ui/views/AddCalendarActivity.kt
@@ -28,7 +28,9 @@ import at.bitfire.icsdroid.model.SubscriptionSettingsModel
 import at.bitfire.icsdroid.model.ValidationModel
 import at.bitfire.icsdroid.ui.screen.AddCalendarScreen
 import at.bitfire.icsdroid.ui.theme.setContentThemed
+import dagger.hilt.android.AndroidEntryPoint
 
+@AndroidEntryPoint
 class AddCalendarActivity : AppCompatActivity() {
 
     companion object {

--- a/app/src/main/java/at/bitfire/icsdroid/ui/views/CalendarListActivity.kt
+++ b/app/src/main/java/at/bitfire/icsdroid/ui/views/CalendarListActivity.kt
@@ -6,7 +6,6 @@ package at.bitfire.icsdroid.ui.views
 
 import android.content.Intent
 import android.os.Bundle
-import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -23,8 +22,11 @@ import at.bitfire.icsdroid.ui.screen.CalendarListScreen
 import at.bitfire.icsdroid.ui.theme.setContentThemed
 import at.bitfire.icsdroid.ui.views.CalendarListActivity.Companion.EXTRA_ERROR_MESSAGE
 import at.bitfire.icsdroid.ui.views.CalendarListActivity.Companion.EXTRA_THROWABLE
+import dagger.hilt.android.AndroidEntryPoint
 import java.util.ServiceLoader
+import javax.inject.Inject
 
+@AndroidEntryPoint
 class CalendarListActivity: AppCompatActivity() {
 
     companion object {
@@ -48,7 +50,8 @@ class CalendarListActivity: AppCompatActivity() {
         const val EXTRA_THROWABLE = "errorThrowable"
     }
 
-    private val model by viewModels<SubscriptionsModel>()
+    @Inject
+    lateinit var model: SubscriptionsModel
 
     /** Stores the calendar permission request for asking for calendar permissions during runtime */
     private lateinit var requestCalendarPermissions: () -> Unit

--- a/app/src/main/java/at/bitfire/icsdroid/ui/views/EditCalendarActivity.kt
+++ b/app/src/main/java/at/bitfire/icsdroid/ui/views/EditCalendarActivity.kt
@@ -11,7 +11,9 @@ import at.bitfire.icsdroid.R
 import at.bitfire.icsdroid.db.entity.Subscription
 import at.bitfire.icsdroid.ui.screen.EditCalendarScreen
 import at.bitfire.icsdroid.ui.theme.setContentThemed
+import dagger.hilt.android.AndroidEntryPoint
 
+@AndroidEntryPoint
 class EditCalendarActivity: AppCompatActivity() {
 
     companion object {
@@ -24,7 +26,6 @@ class EditCalendarActivity: AppCompatActivity() {
         super.onCreate(savedInstanceState)
         setContentThemed {
             EditCalendarScreen(
-                application,
                 subscriptionId = intent.getLongExtra(EXTRA_SUBSCRIPTION_ID, -1),
                 { onShare(it) },
                 { finish() }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,6 +3,7 @@ plugins {
     alias(libs.plugins.aboutLibs) apply false
     alias(libs.plugins.android.application) apply false
     alias(libs.plugins.compose.compiler) apply false
+    alias(libs.plugins.hilt) apply false
     alias(libs.plugins.kapt) apply false
     alias(libs.plugins.kotlin) apply false
     alias(libs.plugins.ksp) apply false

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -5,6 +5,7 @@ androidx-activityCompose = "1.10.1"
 androidx-appCompat = "1.7.1"
 androidx-archCore = "2.2.0"
 androidx-core = "1.16.0"
+androidx-hilt = "1.2.0"
 androidx-lifecycle = "2.9.1"
 androidx-test-junit = "1.2.1"
 androidx-test-rules = "1.6.1"
@@ -19,6 +20,7 @@ compose-runtime = "1.8.3"
 compose-ui = "1.8.3"
 datastore = "1.1.7"
 desugaring = "2.1.5"
+hilt = "2.56.2"
 joda-time = "2.14.0"
 junit = "4.13.2"
 kotlin = "2.1.21"
@@ -34,6 +36,9 @@ androidx-appCompat = { module = "androidx.appcompat:appcompat", version.ref = "a
 androidx-arch-core-testing = { module = "androidx.arch.core:core-testing", version.ref = "androidx-archCore" }
 androidx-core = { module = "androidx.core:core-ktx", version.ref = "androidx-core" }
 androidx-datastore = { module = "androidx.datastore:datastore-preferences", version.ref = "datastore" }
+androidx-hilt-compiler = { module = "androidx.hilt:hilt-compiler", version.ref = "androidx-hilt" }
+androidx-hilt-navigation-compose = { module = "androidx.hilt:hilt-navigation-compose", version.ref = "androidx-hilt" }
+androidx-hilt-work = { module = "androidx.hilt:hilt-work", version.ref = "androidx-hilt" }
 androidx-lifecycle-viewmodel = { module = "androidx.lifecycle:lifecycle-viewmodel-ktx", version.ref = "androidx-lifecycle" }
 androidx-lifecycle-viewmodel-compose = { module = "androidx.lifecycle:lifecycle-viewmodel-compose", version.ref = "androidx-lifecycle" }
 androidx-lifecycle-runtime-compose = { module = "androidx.lifecycle:lifecycle-runtime-compose", version.ref = "androidx-lifecycle" }
@@ -52,6 +57,9 @@ compose-ui-tooling = { module = "androidx.compose.ui:ui-tooling", version.ref = 
 compose-ui-toolingPreview = { module = "androidx.compose.ui:ui-tooling-preview", version.ref = "compose-ui" }
 compose-runtime-livedata = { module = "androidx.compose.runtime:runtime-livedata", version.ref = "compose-runtime" }
 desugaring = { module = "com.android.tools:desugar_jdk_libs", version.ref = "desugaring" }
+hilt-android-base = { module = "com.google.dagger:hilt-android", version.ref = "hilt" }
+hilt-android-compiler = { module = "com.google.dagger:hilt-android-compiler", version.ref = "hilt" }
+hilt-android-testing = { module = "com.google.dagger:hilt-android-testing", version.ref = "hilt" }
 jodaTime = { module = "joda-time:joda-time", version.ref = "joda-time" }
 junit = { module = "junit:junit", version.ref = "junit" }
 kotlinx-coroutines = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-android", version.ref = "kotlinx-coroutines" }
@@ -65,6 +73,7 @@ room-compiler = { module = "androidx.room:room-compiler", version.ref = "room" }
 aboutLibs = { id = "com.mikepenz.aboutlibraries.plugin", version.ref = "aboutLibs" }
 android-application = { id = "com.android.application", version.ref = "agp" }
 compose-compiler = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
+hilt = { id = "com.google.dagger.hilt.android", version.ref = "hilt" }
 kotlin = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 kapt = { id = "org.jetbrains.kotlin.kapt", version.ref = "kotlin" }
 ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }


### PR DESCRIPTION
### Purpose

Using hilt for DI will make the ICSx5 code base resemble more the one of DAVx5 and ease the integration.  

### Short description

- integrated hilt
- use hilt for app database injection
- use hilt for workers
- use hilt in most viewmodels
- make BaseSyncWorker abstract
- adapt tests

**Note**
I consciously tried not to let the PR grow too big, so we can address 
- linting
- copyright comments 
- fixing EditCalendarModel depending on other view models 

in a new PR. Everything should still be in a working state of course, however.

### Checklist

- [X] The PR has a proper title, description and label.
- [X] I have [self-reviewed the PR](https://patrickdinh.medium.com/review-your-own-pull-requests-5634cad10b7a).
