### PR TITLE
Rename activities from calendar to subscription

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -79,7 +79,7 @@
         </service>
 
         <activity
-            android:name=".ui.views.CalendarListActivity"
+            android:name=".ui.views.SubscriptionListActivity"
             android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
@@ -87,8 +87,8 @@
             </intent-filter>
         </activity>
         <activity
-            android:name=".ui.views.AddCalendarActivity"
-            android:parentActivityName=".ui.views.CalendarListActivity"
+            android:name=".ui.views.AddSubscriptionActivity"
+            android:parentActivityName=".ui.views.SubscriptionListActivity"
             android:exported="true"
             android:windowSoftInputMode="adjustResize"
             tools:ignore="UnusedAttribute">
@@ -119,14 +119,14 @@
             </intent-filter>
         </activity>
         <activity
-            android:name=".ui.views.EditCalendarActivity"
+            android:name=".ui.views.EditSubscriptionActivity"
             android:label="@string/activity_edit_calendar"
-            android:parentActivityName=".ui.views.CalendarListActivity"
+            android:parentActivityName=".ui.views.SubscriptionListActivity"
             android:windowSoftInputMode="stateAlwaysHidden" />
         <activity
             android:name=".ui.InfoActivity"
             android:label="@string/activity_app_info"
-            android:parentActivityName=".ui.views.CalendarListActivity" />
+            android:parentActivityName=".ui.views.SubscriptionListActivity" />
 
     </application>
 

--- a/app/src/main/java/at/bitfire/icsdroid/AccountAuthenticatorService.kt
+++ b/app/src/main/java/at/bitfire/icsdroid/AccountAuthenticatorService.kt
@@ -13,7 +13,7 @@ import android.content.Context
 import android.content.Intent
 import android.os.Bundle
 import android.os.IBinder
-import at.bitfire.icsdroid.ui.views.AddCalendarActivity
+import at.bitfire.icsdroid.ui.views.AddSubscriptionActivity
 
 class AccountAuthenticatorService: Service() {
 
@@ -31,7 +31,7 @@ class AccountAuthenticatorService: Service() {
     ): AbstractAccountAuthenticator(context) {
 
         override fun addAccount(response: AccountAuthenticatorResponse?, accountType: String, authTokenType: String?, requiredFeatures: Array<String>?, options: Bundle?): Bundle {
-			val intent = Intent(context, AddCalendarActivity::class.java)
+			val intent = Intent(context, AddSubscriptionActivity::class.java)
 			intent.putExtra(AccountManager.KEY_ACCOUNT_AUTHENTICATOR_RESPONSE, response)
 			val bundle = Bundle(1)
 			bundle.putParcelable(AccountManager.KEY_INTENT, intent)

--- a/app/src/main/java/at/bitfire/icsdroid/ProcessEventsTask.kt
+++ b/app/src/main/java/at/bitfire/icsdroid/ProcessEventsTask.kt
@@ -17,7 +17,7 @@ import at.bitfire.icsdroid.calendar.LocalEvent
 import at.bitfire.icsdroid.db.AppDatabase
 import at.bitfire.icsdroid.db.entity.Subscription
 import at.bitfire.icsdroid.ui.NotificationUtils
-import at.bitfire.icsdroid.ui.views.CalendarListActivity
+import at.bitfire.icsdroid.ui.views.SubscriptionListActivity
 import dagger.hilt.EntryPoint
 import dagger.hilt.InstallIn
 import dagger.hilt.android.EntryPointAccessors
@@ -268,9 +268,9 @@ class ProcessEventsTask(
     private fun notifyError() {
         val exception = exception ?: return
         val message = exception.localizedMessage ?: exception.message ?: exception.toString()
-        val errorIntent = Intent(context, CalendarListActivity::class.java).apply {
-            putExtra(CalendarListActivity.EXTRA_ERROR_MESSAGE, message)
-            putExtra(CalendarListActivity.EXTRA_THROWABLE, exception)
+        val errorIntent = Intent(context, SubscriptionListActivity::class.java).apply {
+            putExtra(SubscriptionListActivity.EXTRA_ERROR_MESSAGE, message)
+            putExtra(SubscriptionListActivity.EXTRA_THROWABLE, exception)
         }
 
         val notificationManager = NotificationUtils.createChannels(context)

--- a/app/src/main/java/at/bitfire/icsdroid/ui/NotificationUtils.kt
+++ b/app/src/main/java/at/bitfire/icsdroid/ui/NotificationUtils.kt
@@ -12,7 +12,7 @@ import android.content.Intent
 import android.os.Build
 import androidx.core.app.NotificationCompat
 import at.bitfire.icsdroid.R
-import at.bitfire.icsdroid.ui.views.CalendarListActivity
+import at.bitfire.icsdroid.ui.views.SubscriptionListActivity
 
 object NotificationUtils {
 
@@ -37,8 +37,8 @@ object NotificationUtils {
      */
     fun showCalendarPermissionNotification(context: Context) {
         val nm = createChannels(context)
-        val askPermissionsIntent = Intent(context, CalendarListActivity::class.java).apply {
-            putExtra(CalendarListActivity.EXTRA_REQUEST_CALENDAR_PERMISSION, true)
+        val askPermissionsIntent = Intent(context, SubscriptionListActivity::class.java).apply {
+            putExtra(SubscriptionListActivity.EXTRA_REQUEST_CALENDAR_PERMISSION, true)
         }
         val notification = NotificationCompat.Builder(context, CHANNEL_SYNC)
             .setSmallIcon(R.drawable.ic_sync_problem_white)

--- a/app/src/main/java/at/bitfire/icsdroid/ui/screen/SubscriptionsScreen.kt
+++ b/app/src/main/java/at/bitfire/icsdroid/ui/screen/SubscriptionsScreen.kt
@@ -54,7 +54,7 @@ import at.bitfire.icsdroid.ui.partials.CalendarListItem
 import at.bitfire.icsdroid.ui.partials.ExtendedTopAppBar
 import at.bitfire.icsdroid.ui.partials.GenericAlertDialog
 import at.bitfire.icsdroid.ui.partials.SyncIntervalDialog
-import at.bitfire.icsdroid.ui.views.CalendarListActivity
+import at.bitfire.icsdroid.ui.views.SubscriptionListActivity
 
 @Composable
 fun SubscriptionsScreen(
@@ -393,7 +393,7 @@ fun ActionOverflowMenu(
             text = { Text(stringResource(R.string.calendar_list_privacy_policy)) },
             onClick = {
                 showMenu = false
-                UriUtils.launchUri(context, Uri.parse(CalendarListActivity.PRIVACY_POLICY_URL))
+                UriUtils.launchUri(context, Uri.parse(SubscriptionListActivity.PRIVACY_POLICY_URL))
             }
         )
         DropdownMenuItem(

--- a/app/src/main/java/at/bitfire/icsdroid/ui/views/AddSubscriptionActivity.kt
+++ b/app/src/main/java/at/bitfire/icsdroid/ui/views/AddSubscriptionActivity.kt
@@ -28,7 +28,7 @@ import at.bitfire.icsdroid.ui.theme.setContentThemed
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
-class AddCalendarActivity : AppCompatActivity() {
+class AddSubscriptionActivity : AppCompatActivity() {
 
     companion object {
         const val EXTRA_TITLE = "title"

--- a/app/src/main/java/at/bitfire/icsdroid/ui/views/EditSubscriptionActivity.kt
+++ b/app/src/main/java/at/bitfire/icsdroid/ui/views/EditSubscriptionActivity.kt
@@ -14,7 +14,7 @@ import at.bitfire.icsdroid.ui.theme.setContentThemed
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
-class EditCalendarActivity: AppCompatActivity() {
+class EditSubscriptionActivity: AppCompatActivity() {
 
     companion object {
         // Used by intents only

--- a/app/src/main/java/at/bitfire/icsdroid/ui/views/SubscriptionListActivity.kt
+++ b/app/src/main/java/at/bitfire/icsdroid/ui/views/SubscriptionListActivity.kt
@@ -20,14 +20,14 @@ import at.bitfire.icsdroid.ui.InfoActivity
 import at.bitfire.icsdroid.ui.partials.AlertDialog
 import at.bitfire.icsdroid.ui.screen.SubscriptionsScreen
 import at.bitfire.icsdroid.ui.theme.setContentThemed
-import at.bitfire.icsdroid.ui.views.CalendarListActivity.Companion.EXTRA_ERROR_MESSAGE
-import at.bitfire.icsdroid.ui.views.CalendarListActivity.Companion.EXTRA_THROWABLE
+import at.bitfire.icsdroid.ui.views.SubscriptionListActivity.Companion.EXTRA_ERROR_MESSAGE
+import at.bitfire.icsdroid.ui.views.SubscriptionListActivity.Companion.EXTRA_THROWABLE
 import dagger.hilt.android.AndroidEntryPoint
 import java.util.ServiceLoader
 import javax.inject.Inject
 
 @AndroidEntryPoint
-class CalendarListActivity: AppCompatActivity() {
+class SubscriptionListActivity: AppCompatActivity() {
 
     companion object {
         /**
@@ -107,13 +107,13 @@ class CalendarListActivity: AppCompatActivity() {
                     startActivity(Intent(this, InfoActivity::class.java))
                 },
                 onAddRequested = {
-                    startActivity(Intent(this, AddCalendarActivity::class.java))
+                    startActivity(Intent(this, AddSubscriptionActivity::class.java))
                 },
                 onRequestCalendarPermissions = requestCalendarPermissions,
                 onRequestNotificationPermission = requestNotificationPermission,
                 onItemSelected = { subscription ->
-                    val intent = Intent(this, EditCalendarActivity::class.java)
-                    intent.putExtra(EditCalendarActivity.EXTRA_SUBSCRIPTION_ID, subscription.id)
+                    val intent = Intent(this, EditSubscriptionActivity::class.java)
+                    intent.putExtra(EditSubscriptionActivity.EXTRA_SUBSCRIPTION_ID, subscription.id)
                     startActivity(intent)
                 }
             )


### PR DESCRIPTION
### Purpose

Consistent naming throughout the code base.

### Short description

- Rename activities from containing "Calendar" to "Subscription"

### Checklist

- [X] The PR has a proper title, description and label.
- [X] I have [self-reviewed the PR](https://patrickdinh.medium.com/review-your-own-pull-requests-5634cad10b7a).
