### PR TITLE
Fix about app dialog

### DIFF
--- a/app/src/main/java/at/bitfire/icsdroid/ui/InfoActivity.kt
+++ b/app/src/main/java/at/bitfire/icsdroid/ui/InfoActivity.kt
@@ -58,9 +58,11 @@ import at.bitfire.icsdroid.ui.partials.GenericAlertDialog
 import at.bitfire.icsdroid.ui.theme.setContentThemed
 import com.mikepenz.aboutlibraries.ui.compose.m3.LibrariesContainer
 import com.mikepenz.aboutlibraries.ui.compose.rememberLibraries
+import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.runBlocking
 import java.util.ServiceLoader
 
+@AndroidEntryPoint
 class InfoActivity: AppCompatActivity() {
 
     /**


### PR DESCRIPTION
### Purpose

When migrating to Hilt, we forgot annotating the `InfoActivity` class.

### Short description

- Added missing annotation

### Checklist

- [x] The PR has a proper title, description and label.
- [x] I have [self-reviewed the PR](https://patrickdinh.medium.com/review-your-own-pull-requests-5634cad10b7a).
- [x] I have added documentation to complex functions and functions that can be used by other modules.
- [x] I have added reasonable tests or consciously decided to not add tests.
