### PR TITLE
Enable debug logging for work manager

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -49,7 +49,8 @@
         android:enableOnBackInvokedCallback="true"
         tools:ignore="UnusedAttribute">
 
-        <!-- required for Hilt/WorkManager integration -->
+        <!-- Disable all initialization -->
+        <!-- to use custom initialization needed when using work manager with hilt -->
         <provider
             android:name="androidx.startup.InitializationProvider"
             android:authorities="${applicationId}.androidx-startup"

--- a/app/src/main/java/at/bitfire/icsdroid/App.kt
+++ b/app/src/main/java/at/bitfire/icsdroid/App.kt
@@ -19,6 +19,7 @@ class App : Application(), Configuration.Provider {
     override val workManagerConfiguration: Configuration
         get() = Configuration.Builder()
             .setWorkerFactory(workerFactory)
+            .setMinimumLoggingLevel(android.util.Log.DEBUG)
             .build()
 
 }


### PR DESCRIPTION
### Purpose

We need to find out why the background sync sometimes does not run for some users. 

### Short description

- Enable debug-logging for work manager in production builds


### Checklist

- [X] The PR has a proper title, description and label.
- [X] I have [self-reviewed the PR](https://patrickdinh.medium.com/review-your-own-pull-requests-5634cad10b7a).
