### PR TITLE
Run `checkSyncSettings` on lifecycle resume

### DIFF
--- a/app/src/main/java/at/bitfire/icsdroid/ui/screen/SubscriptionsScreen.kt
+++ b/app/src/main/java/at/bitfire/icsdroid/ui/screen/SubscriptionsScreen.kt
@@ -49,6 +49,7 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.core.net.toUri
 import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.LifecycleResumeEffect
 import at.bitfire.icsdroid.MainActivity
 import at.bitfire.icsdroid.PermissionUtils
 import at.bitfire.icsdroid.R
@@ -82,11 +83,15 @@ fun SubscriptionsScreen(
         model.checkSyncSettings()
     }
 
+    LifecycleResumeEffect(Unit) {
+        model.checkSyncSettings()
+
+        onPauseOrDispose { /* nothing */ }
+    }
+
     LaunchedEffect(Unit) {
         if (requestPermissions && !PermissionUtils.haveCalendarPermissions(context))
             requestCalendarPermissions()
-
-        model.checkSyncSettings()
     }
 
     SubscriptionsScreen(


### PR DESCRIPTION
### Purpose

Before #640 we were calling `checkSyncSettings` in the activity's [`onResume`](https://github.com/bitfireAT/icsx5/pull/640/files#diff-25f544a56fb9bce003222f372d4bc69760e4da19e90a75373d0ab891cfea48f7L123-L126) function.

However, after the PR, it was replaced by a simple `LaunchedEffect`. It should be `LifecycleResumeEffect` to match the original behavior.

### Short description

Moved `checkSyncSettings` to a `LifecycleResumeEffect`.

### Checklist

- [x] The PR has a proper title, description and label.
- [x] I have [self-reviewed the PR](https://patrickdinh.medium.com/review-your-own-pull-requests-5634cad10b7a).
- [x] I have added documentation to complex functions and functions that can be used by other modules.
- [x] I have added reasonable tests or consciously decided to not add tests.
