### PR TITLE
Enable grouping just like the other repos

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,7 +9,15 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"
+    commit-message:
+      prefix: "[CI] "
+    groups:
+      ci-actions:
+        patterns: ["*"]
   - package-ecosystem: "gradle"
     directory: "/" # Location of package manifests
     schedule:
       interval: "daily"
+    groups:
+      lib-dependencies:
+        patterns: ["*"]


### PR DESCRIPTION
### Purpose

Followed the other bitfire respos with the Dependabot grouping feature.

### Short description

- Added groups

### Checklist

- [x] The PR has a proper title, description and label.
- [x] I have [self-reviewed the PR](https://patrickdinh.medium.com/review-your-own-pull-requests-5634cad10b7a).
- [x] I have added documentation to complex functions and functions that can be used by other modules.
- [x] I have added reasonable tests or consciously decided to not add tests.
