### PR TITLE
Provide custom user agent suggestions

### DIFF
--- a/app/src/main/java/at/bitfire/icsdroid/Constants.kt
+++ b/app/src/main/java/at/bitfire/icsdroid/Constants.kt
@@ -14,4 +14,13 @@ object Constants {
 
     val USER_AGENT = "ICSx5/${BuildConfig.VERSION_NAME} (ical4j/${ical4jVersion} okhttp/${OkHttp.VERSION} Android/${Build.VERSION.RELEASE})"
 
+    /**
+     * Suggested user agents to allow compatibility with user agent blocking servers
+     */
+    val COMPATIBILITY_USER_AGENTS = mapOf(
+        "Chrome Android" to "Mozilla/5.0 (Linux; Android 10; K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/134.0.0.0 Mobile Safari/537.3",
+        "Firefox Android" to "Mozilla/5.0 (Android 16; Mobile; rv:142.0) Gecko/142.0 Firefox/142.0",
+        "Safari iOS" to "Mozilla/5.0 (iPhone; CPU iPhone OS 18_3_2 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/18.3.1 Mobile/15E148 Safari/604."
+    )
+
 }

--- a/app/src/main/java/at/bitfire/icsdroid/ui/partials/CustomUserAgentInput.kt
+++ b/app/src/main/java/at/bitfire/icsdroid/ui/partials/CustomUserAgentInput.kt
@@ -1,18 +1,17 @@
 package at.bitfire.icsdroid.ui.partials
 
-import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.text.KeyboardActions
-import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
+import at.bitfire.icsdroid.Constants.COMPATIBILITY_USER_AGENTS
 import at.bitfire.icsdroid.R
 
 @Composable
 fun CustomUserAgentInput(
-    onValueChange: (String?) -> Unit,
     value: String?,
+    onValueChange: (String?) -> Unit,
     keyboardActions: KeyboardActions = KeyboardActions.Default
 ) {
     ToggleContent(
@@ -21,11 +20,12 @@ fun CustomUserAgentInput(
         initialToggleState = value != null,
         onStateChange = { checked -> if (!checked) onValueChange(null) },
     ) {
-        OutlinedTextField(
+        DropDownTextField(
             value = value ?: "",
             onValueChange = onValueChange,
+            options = COMPATIBILITY_USER_AGENTS,
+            modifier = Modifier,
             label = { Text(stringResource(R.string.add_calendar_custom_user_agent_label)) },
-            modifier = Modifier.fillMaxWidth(),
             keyboardActions = keyboardActions
         )
     }

--- a/app/src/main/java/at/bitfire/icsdroid/ui/partials/CustomUserAgentInput.kt
+++ b/app/src/main/java/at/bitfire/icsdroid/ui/partials/CustomUserAgentInput.kt
@@ -1,39 +1,26 @@
 package at.bitfire.icsdroid.ui.partials
 
-import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.saveable.rememberSaveable
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import at.bitfire.icsdroid.R
 
 @Composable
-fun ToggleTextField(
-    title: String,
-    description: String,
+fun CustomUserAgentInput(
     onValueChange: (String?) -> Unit,
     value: String?,
     keyboardActions: KeyboardActions = KeyboardActions.Default
 ) {
-    var showTextField by rememberSaveable { mutableStateOf(value != null) }
-    SwitchSetting(
-        title = title,
-        description = description,
-        checked = showTextField,
-        onCheckedChange = {
-            showTextField = !showTextField
-            if (!showTextField)
-                onValueChange(null)
-        }
-    )
-    AnimatedVisibility(visible = showTextField) {
+    ToggleContent(
+        title = stringResource(R.string.add_calendar_custom_user_agent_title),
+        description = stringResource(R.string.add_calendar_custom_user_agent_description),
+        initialToggleState = value != null,
+        onStateChange = { checked -> if (!checked) onValueChange(null) },
+    ) {
         OutlinedTextField(
             value = value ?: "",
             onValueChange = onValueChange,

--- a/app/src/main/java/at/bitfire/icsdroid/ui/partials/DropDownTextField.kt
+++ b/app/src/main/java/at/bitfire/icsdroid/ui/partials/DropDownTextField.kt
@@ -1,0 +1,83 @@
+package at.bitfire.icsdroid.ui.partials
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.text.KeyboardActions
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.KeyboardArrowDown
+import androidx.compose.material.icons.filled.KeyboardArrowUp
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.Icon
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.layout.onGloballyPositioned
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.unit.toSize
+
+
+@Composable
+fun DropDownTextField(
+    value: String?,
+    onValueChange: (String) -> Unit,
+    options: Map<String, String>,
+    modifier: Modifier = Modifier,
+    label: @Composable (() -> Unit)? = null,
+    keyboardActions: KeyboardActions = KeyboardActions.Default
+) {
+    var expanded by remember { mutableStateOf(false) }
+    var textFieldSize by remember { mutableStateOf(Size.Zero)}
+
+    Column {
+        OutlinedTextField(
+            value = value ?: "",
+            onValueChange = onValueChange,
+            keyboardActions = keyboardActions,
+            modifier = modifier
+                .fillMaxWidth()
+                .onGloballyPositioned { coordinates ->
+                    // Remember text field size
+                    textFieldSize = coordinates.size.toSize()
+                },
+            label = label,
+            trailingIcon = {
+                // Open/Close dropdown icon
+                Icon(
+                    imageVector = if (expanded)
+                        Icons.Filled.KeyboardArrowUp
+                    else
+                        Icons.Filled.KeyboardArrowDown,
+                    contentDescription = null,
+                    modifier = modifier.clickable { expanded = !expanded }
+                )
+            }
+        )
+        DropdownMenu(
+            expanded = expanded,
+            onDismissRequest = { expanded = false },
+            modifier = modifier.width(with(LocalDensity.current) {
+                // Make drop down menu same length as text field
+                textFieldSize.width.toDp()
+            })
+        ) {
+            options.forEach { (label, option) ->
+                DropdownMenuItem(
+                    text = { Text(text = label) },
+                    onClick = {
+                        onValueChange(option)
+                        expanded = false
+                    }
+                )
+            }
+        }
+    }
+}

--- a/app/src/main/java/at/bitfire/icsdroid/ui/partials/ToggleContent.kt
+++ b/app/src/main/java/at/bitfire/icsdroid/ui/partials/ToggleContent.kt
@@ -1,0 +1,31 @@
+package at.bitfire.icsdroid.ui.partials
+
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+
+@Composable
+fun ToggleContent(
+    title: String,
+    description: String,
+    initialToggleState: Boolean,
+    onStateChange: (Boolean) -> Unit,
+    content: @Composable () -> Unit
+) {
+    var showTextField by rememberSaveable { mutableStateOf(initialToggleState) }
+    SwitchSetting(
+        title = title,
+        description = description,
+        checked = showTextField,
+        onCheckedChange = {
+            showTextField = !showTextField
+            onStateChange(showTextField)
+        }
+    )
+    AnimatedVisibility(visible = showTextField) {
+        content()
+    }
+}

--- a/app/src/main/java/at/bitfire/icsdroid/ui/screen/EditSubscriptionScreen.kt
+++ b/app/src/main/java/at/bitfire/icsdroid/ui/screen/EditSubscriptionScreen.kt
@@ -39,7 +39,7 @@ import at.bitfire.icsdroid.model.EditSubscriptionModel
 import at.bitfire.icsdroid.model.EditSubscriptionModel.EditSubscriptionModelFactory
 import at.bitfire.icsdroid.ui.partials.ExtendedTopAppBar
 import at.bitfire.icsdroid.ui.partials.GenericAlertDialog
-import at.bitfire.icsdroid.ui.partials.ToggleTextField
+import at.bitfire.icsdroid.ui.partials.CustomUserAgentInput
 import at.bitfire.icsdroid.ui.theme.AppTheme
 import at.bitfire.icsdroid.ui.views.LoginCredentialsComposable
 import at.bitfire.icsdroid.ui.views.SubscriptionSettingsComposable
@@ -174,11 +174,9 @@ fun EditSubscriptionScreen(
             )
 
             // Custom User Agent
-            ToggleTextField(
-                title = stringResource(R.string.add_calendar_custom_user_agent_title),
-                description = stringResource(R.string.add_calendar_custom_user_agent_description),
-                onValueChange = customUserAgentChanged,
-                value = customUserAgent
+            CustomUserAgentInput(
+                value = customUserAgent,
+                onValueChange = customUserAgentChanged
             )
 
             Spacer(modifier = Modifier.padding(12.dp))

--- a/app/src/main/java/at/bitfire/icsdroid/ui/views/EnterUrlComposable.kt
+++ b/app/src/main/java/at/bitfire/icsdroid/ui/views/EnterUrlComposable.kt
@@ -57,7 +57,7 @@ import androidx.compose.ui.unit.em
 import at.bitfire.icsdroid.R
 import at.bitfire.icsdroid.ui.ResourceInfo
 import at.bitfire.icsdroid.ui.partials.AlertDialog
-import at.bitfire.icsdroid.ui.partials.ToggleTextField
+import at.bitfire.icsdroid.ui.partials.CustomUserAgentInput
 import kotlinx.coroutines.launch
 
 @OptIn(ExperimentalFoundationApi::class)
@@ -287,11 +287,9 @@ private fun ColumnScope.SubscribeToUrl(
             )
 
             // Custom User Agent
-            ToggleTextField(
-                title = stringResource(R.string.add_calendar_custom_user_agent_title),
-                description = stringResource(R.string.add_calendar_custom_user_agent_description),
-                onValueChange = onCustomUserAgentChange,
+            CustomUserAgentInput(
                 value = customUserAgent,
+                onValueChange = onCustomUserAgentChange,
                 keyboardActions = KeyboardActions { onSubmit() }
             )
         }


### PR DESCRIPTION
### Purpose

Non-technical users might not know what string to enter into the custom user agent field.

### Short description

- refactor: Make `ToggleTextField` composable a generic `ToggleContent` composable and use in specific `CustomUserAgentComposable`
- replace the normal textfield with new `DropDownTextField` in `CustomUserAgentComposable`
- add three common mobile browser strings

### Checklist

- [X] The PR has a proper title, description and label.
- [ ] I have [self-reviewed the PR](https://patrickdinh.medium.com/review-your-own-pull-requests-5634cad10b7a).
- [ ] I have added documentation to complex functions and functions that can be used by other modules.
- [ ] I have added reasonable tests or consciously decided to not add tests.
