### PR TITLE
Globally disable follow redirects

### DIFF
--- a/app/src/main/java/at/bitfire/icsdroid/AppHttpClient.kt
+++ b/app/src/main/java/at/bitfire/icsdroid/AppHttpClient.kt
@@ -71,8 +71,6 @@ class AppHttpClient @AssistedInject constructor(
                 sslSocketFactory(sslContext.socketFactory, certManager)
                 hostnameVerifier(certManager.HostnameVerifier(OkHostnameVerifier))
             }
-        } else {
-            followRedirects = false
         }
     }
 

--- a/app/src/main/java/at/bitfire/icsdroid/AppHttpClient.kt
+++ b/app/src/main/java/at/bitfire/icsdroid/AppHttpClient.kt
@@ -68,7 +68,6 @@ class AppHttpClient @AssistedInject constructor(
         if (engine is OkHttpEngine) (this as HttpClientConfig<OkHttpConfig>).engine {
             addNetworkInterceptor(BrotliInterceptor)
             config {
-                followRedirects(false)
                 sslSocketFactory(sslContext.socketFactory, certManager)
                 hostnameVerifier(certManager.HostnameVerifier(OkHostnameVerifier))
             }

--- a/app/src/main/java/at/bitfire/icsdroid/AppHttpClient.kt
+++ b/app/src/main/java/at/bitfire/icsdroid/AppHttpClient.kt
@@ -64,6 +64,9 @@ class AppHttpClient @AssistedInject constructor(
             socketTimeoutMillis = 60_000
         }
 
+        // Disable redirect following, it's handled by CalendarFetcher
+        followRedirects = false
+
         @Suppress("UNCHECKED_CAST")
         if (engine is OkHttpEngine) (this as HttpClientConfig<OkHttpConfig>).engine {
             addNetworkInterceptor(BrotliInterceptor)


### PR DESCRIPTION
### Purpose

~We are _trying_ to disable redirection following in the engine config. We don't even want to disable redirection, so remove that line.~

We do have to disable redirection, it's handled by `CalendarFetcher`. Following [the docs](https://ktor.io/docs/client-redirect.html), this is the way to disable it so it can be handled by it.

### Short description

- ~Remove the redirection disable in engine config.~
- Move the redirection disabling
- Add a comment to make sure we don't get confused again in the future.

### Checklist

- [x] The PR has a proper title, description and label.
- [x] I have [self-reviewed the PR](https://patrickdinh.medium.com/review-your-own-pull-requests-5634cad10b7a).
- [x] I have added documentation to complex functions and functions that can be used by other modules.
- [x] I have added reasonable tests or consciously decided to not add tests.
