### PR TITLE
Ignore ClosedByteChannelException in CalendarFetcher

### DIFF
--- a/app/src/main/java/at/bitfire/icsdroid/CalendarFetcher.kt
+++ b/app/src/main/java/at/bitfire/icsdroid/CalendarFetcher.kt
@@ -182,6 +182,8 @@ open class CalendarFetcher(
                 }
             }
         } catch (e: ClosedByteChannelException) {
+            // Ignore ClosedByteChannelException which is thrown ProtocolException is thrown which
+            // happens when when servers misbehave and for example send more bytes than expected.
             Log.i(Constants.TAG, "Ignoring ClosedByteChannelException", e)
         } catch (e: Exception) {
             onError(e)


### PR DESCRIPTION
### Purpose

Ignore ClosedByteChannelException which is thrown ProtocolException is thrown which happens when when servers misbehave and for example send more bytes than expected.

### Short description

- catch and ignore `ClosedByteChannelException`

### Checklist

- [x] The PR has a proper title, description and label.
- [x] I have [self-reviewed the PR](https://patrickdinh.medium.com/review-your-own-pull-requests-5634cad10b7a).
- [x] I have added documentation to complex functions and functions that can be used by other modules.
- [x] I have added reasonable tests or consciously decided to not add tests.
