### PR TITLE
Only update `uiState` once in `checkSyncSettings`

### DIFF
--- a/app/src/main/java/at/bitfire/icsdroid/model/SubscriptionsModel.kt
+++ b/app/src/main/java/at/bitfire/icsdroid/model/SubscriptionsModel.kt
@@ -112,18 +112,14 @@ class SubscriptionsModel @Inject constructor(
      */
     fun checkSyncSettings() = viewModelScope.launch(Dispatchers.IO) {
         val haveNotificationPermission = PermissionUtils.haveNotificationPermission(context)
-        uiState = uiState.copy(askForNotificationPermission = !haveNotificationPermission)
 
         val haveCalendarPermission = PermissionUtils.haveCalendarPermissions(context)
-        uiState = uiState.copy(askForCalendarPermission = !haveCalendarPermission)
 
         val powerManager = context.getSystemService<PowerManager>()
-        val isIgnoringBatteryOptimizations = powerManager?.isIgnoringBatteryOptimizations(
-            BuildConfig.APPLICATION_ID)
+        val isIgnoringBatteryOptimizations = powerManager?.isIgnoringBatteryOptimizations(BuildConfig.APPLICATION_ID)
 
         // If not ignoring battery optimizations, and sync interval is less than a day
         val shouldWhitelistApp = isIgnoringBatteryOptimizations == false
-        uiState = uiState.copy(askForWhitelisting = shouldWhitelistApp)
 
         // Make sure permissions are not revoked automatically
         val isAutoRevokeWhitelisted = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
@@ -131,7 +127,12 @@ class SubscriptionsModel @Inject constructor(
         } else {
             true
         }
-        uiState = uiState.copy(askForAutoRevoke = !isAutoRevokeWhitelisted)
+        uiState = uiState.copy(
+            askForAutoRevoke = !isAutoRevokeWhitelisted,
+            askForCalendarPermission = !haveCalendarPermission,
+            askForNotificationPermission = !haveNotificationPermission,
+            askForWhitelisting = shouldWhitelistApp,
+        )
     }
 
     fun onRefreshRequested() {


### PR DESCRIPTION
### Purpose

I think we were updating `uiState` too many times in so little time.

### Short description

Joined the multiple `uiState` updates and copying to a single call in `checkSyncSettings`.

Closes #658

### Checklist

- [x] The PR has a proper title, description and label.
- [x] I have [self-reviewed the PR](https://patrickdinh.medium.com/review-your-own-pull-requests-5634cad10b7a).
- [x] I have added documentation to complex functions and functions that can be used by other modules.
- [x] I have added reasonable tests or consciously decided to not add tests.
