### PR TITLE
Model is not cleared when adding a new subscription

### DIFF
--- a/app/src/main/java/at/bitfire/icsdroid/model/SubscriptionSettingsUseCase.kt
+++ b/app/src/main/java/at/bitfire/icsdroid/model/SubscriptionSettingsUseCase.kt
@@ -98,6 +98,24 @@ class SubscriptionSettingsUseCase @Inject constructor() {
         )
     }
 
+    /**
+     * Set initial values when creating a new subscription.
+     *
+     * Note that all values will be overwritten, so call this method before changing any individual
+     * value, or when you want to reset the form to an initial state.
+     */
+    fun setInitialValues(
+        title: String?,
+        color: Int?,
+        url: String?,
+    ) {
+        uiState = UiState(
+            title = title,
+            color = color,
+            url = url,
+        )
+    }
+
     fun equalsSubscription(subscription: Subscription) =
         uiState.url == subscription.url.toString()
             && uiState.title == subscription.displayName

--- a/app/src/main/java/at/bitfire/icsdroid/ui/screen/AddSubscriptionScreen.kt
+++ b/app/src/main/java/at/bitfire/icsdroid/ui/screen/AddSubscriptionScreen.kt
@@ -78,11 +78,10 @@ fun AddSubscriptionScreen(
         }
     }
 
-    LaunchedEffect(Unit) {
-        title?.let(model.subscriptionSettingsUseCase::setTitle)
-        color?.let(model.subscriptionSettingsUseCase::setColor)
-        url?.let {
-            model.subscriptionSettingsUseCase.setUrl(it)
+    LaunchedEffect(title, color, url) {
+        model.subscriptionSettingsUseCase.setInitialValues(title, color, url)
+
+        if (url != null) {
             model.checkUrlIntroductionPage()
         }
     }
@@ -110,28 +109,26 @@ fun AddSubscriptionScreen(
 
     Box(modifier = Modifier.imePadding()) {
         AddSubscriptionScreen(
+            model = model,
             onPickFileRequested = { pickFile.launch(arrayOf("text/calendar")) },
-            finish = onBackRequested,
-            checkUrlIntroductionPage = model::checkUrlIntroductionPage
+            finish = onBackRequested
         )
     }
 }
 
 @Composable
 fun AddSubscriptionScreen(
+    model: AddSubscriptionModel,
     onPickFileRequested: () -> Unit,
-    checkUrlIntroductionPage: () -> Unit,
     finish: () -> Unit
 ) {
     val scope = rememberCoroutineScope()
     val pagerState = rememberPagerState { 2 }
 
-    val model: AddSubscriptionModel = hiltViewModel()
-
     // Receive updates for the URL introduction page
     with(model.subscriptionSettingsUseCase.uiState) {
         LaunchedEffect(url, requiresAuth, username, password) {
-            checkUrlIntroductionPage()
+            model.checkUrlIntroductionPage()
         }
     }
 


### PR DESCRIPTION
### Purpose

See #696.

### Short description

- We were initializing two different `AddSubscriptionModel`.

  Even though most of the times it's not recommended to pass models between composables. In this case, since there's so much logic there, I think it's better to just keep it split as it was, and pass the view model to simplify the code.

- Added `SubscriptionSettingsUseCase.setInitialValues` to initialize the form when `AddSubscriptionScreen` is launched.

_An animation is still shown for a split of a second, but I think we can live with that._

### Checklist

- [x] The PR has a proper title, description and label.
- [x] I have [self-reviewed the PR](https://patrickdinh.medium.com/review-your-own-pull-requests-5634cad10b7a).
- [x] I have added documentation to complex functions and functions that can be used by other modules.
- [x] I have added reasonable tests or consciously decided to not add tests.
