### PR TITLE
Exit screen after removing subscription

### DIFF
--- a/app/src/main/java/at/bitfire/icsdroid/model/EditSubscriptionModel.kt
+++ b/app/src/main/java/at/bitfire/icsdroid/model/EditSubscriptionModel.kt
@@ -143,18 +143,16 @@ class EditSubscriptionModel @AssistedInject constructor(
     /**
      * Removes the loaded subscription.
      */
-    fun removeSubscription() {
-        viewModelScope.launch(Dispatchers.IO) {
-            subscriptionWithCredential?.let { (subscription) ->
-                db.subscriptionsDao().delete(subscription)
+    fun removeSubscription() = viewModelScope.launch(Dispatchers.IO) {
+        subscriptionWithCredential?.let { (subscription) ->
+            db.subscriptionsDao().delete(subscription)
 
-                // sync the subscription to reflect the changes in the calendar provider
-                SyncWorker.run(context)
+            // sync the subscription to reflect the changes in the calendar provider
+            SyncWorker.run(context)
 
-                // notify UI about success
-                showMessage(R.string.edit_calendar_deleted)
-            } ?: Log.w(Constants.TAG, "There's no subscription to remove")
-        }
+            // notify UI about success
+            showMessage(R.string.edit_calendar_deleted)
+        } ?: Log.w(Constants.TAG, "There's no subscription to remove")
     }
 
 }

--- a/app/src/main/java/at/bitfire/icsdroid/ui/screen/EditSubscriptionScreen.kt
+++ b/app/src/main/java/at/bitfire/icsdroid/ui/screen/EditSubscriptionScreen.kt
@@ -36,9 +36,9 @@ import at.bitfire.icsdroid.R
 import at.bitfire.icsdroid.db.entity.Subscription
 import at.bitfire.icsdroid.model.EditSubscriptionModel
 import at.bitfire.icsdroid.model.EditSubscriptionModel.EditSubscriptionModelFactory
+import at.bitfire.icsdroid.ui.partials.CustomUserAgentInput
 import at.bitfire.icsdroid.ui.partials.ExtendedTopAppBar
 import at.bitfire.icsdroid.ui.partials.GenericAlertDialog
-import at.bitfire.icsdroid.ui.partials.CustomUserAgentInput
 import at.bitfire.icsdroid.ui.theme.AppTheme
 import at.bitfire.icsdroid.ui.views.LoginCredentialsComposable
 import at.bitfire.icsdroid.ui.views.SubscriptionSettingsComposable
@@ -57,7 +57,9 @@ fun EditSubscriptionScreen(
         EditSubscriptionScreen(
             inputValid = model.inputValid,
             modelsDirty = model.modelsDirty,
-            onDelete = model::removeSubscription,
+            onDelete = {
+                model.removeSubscription().invokeOnCompletion { onExit() }
+            },
             onSave = {
                 model.updateSubscription().invokeOnCompletion { onExit() }
             },


### PR DESCRIPTION
### Purpose

Fix #695

### Short description

Followed the same approach as `updateSubscription`, to call `onExit` when the job is done.

### Checklist

- [x] The PR has a proper title, description and label.
- [x] I have [self-reviewed the PR](https://patrickdinh.medium.com/review-your-own-pull-requests-5634cad10b7a).
- [x] I have added documentation to complex functions and functions that can be used by other modules.
- [x] I have added reasonable tests or consciously decided to not add tests.
