### PR TITLE
Add imePadding in EditSubscriptionScreen.kt

### DIFF
--- a/app/src/main/java/at/bitfire/icsdroid/ui/screen/EditSubscriptionScreen.kt
+++ b/app/src/main/java/at/bitfire/icsdroid/ui/screen/EditSubscriptionScreen.kt
@@ -9,6 +9,7 @@ import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
@@ -149,6 +150,7 @@ fun EditSubscriptionScreen(
                 .verticalScroll(rememberScrollState())
                 .padding(paddingValues)
                 .padding(16.dp)
+                .imePadding()
         ) {
             SubscriptionSettingsComposable(
                 modifier = Modifier.fillMaxWidth(),


### PR DESCRIPTION
### Purpose

In `EditSubscriptionScreen` only: Keyboard overlays bottom part of screen (can't scroll to show content below keyboard).

### Short description

- add `imePadding()` to scaffold

### Checklist

- [x] The PR has a proper title, description and label.
- [x] I have [self-reviewed the PR](https://patrickdinh.medium.com/review-your-own-pull-requests-5634cad10b7a).
- [X] I have added documentation to complex functions and functions that can be used by other modules.
- [X] I have added reasonable tests or consciously decided to not add tests.
