### PR TITLE
Fix screen orientation change clearing UI state

### DIFF
--- a/app/src/main/java/at/bitfire/icsdroid/model/SubscriptionSettingsUseCase.kt
+++ b/app/src/main/java/at/bitfire/icsdroid/model/SubscriptionSettingsUseCase.kt
@@ -8,9 +8,7 @@ import at.bitfire.icsdroid.HttpUtils
 import at.bitfire.icsdroid.db.entity.Credential
 import at.bitfire.icsdroid.db.entity.Subscription
 import javax.inject.Inject
-import javax.inject.Singleton
 
-@Singleton
 class SubscriptionSettingsUseCase @Inject constructor() {
     data class UiState(
         val url: String? = null,
@@ -35,6 +33,8 @@ class SubscriptionSettingsUseCase @Inject constructor() {
         val validUrlInput: Boolean = url?.let { url ->
             HttpUtils.acceptedProtocol(url.toUri())
         } ?: false
+
+        fun isInitialized() = url != null || title != null || color != null
     }
 
     var uiState by mutableStateOf(UiState())

--- a/app/src/main/java/at/bitfire/icsdroid/ui/screen/AddSubscriptionScreen.kt
+++ b/app/src/main/java/at/bitfire/icsdroid/ui/screen/AddSubscriptionScreen.kt
@@ -79,6 +79,8 @@ fun AddSubscriptionScreen(
     }
 
     LaunchedEffect(title, color, url) {
+        if (model.subscriptionSettingsUseCase.uiState.isInitialized())
+            return@LaunchedEffect
         model.subscriptionSettingsUseCase.setInitialValues(title, color, url)
 
         if (url != null) {


### PR DESCRIPTION
### Purpose

See #719

### Short description

- Added a new check: `SubscriptionSettingsUseCase.UiState.isInitialized`. Will just check whether the "initialization values" have been set (by `setInitialValues` for example).
- This check is used in the `LaunchedEffect` block of `AddSubscriptionScreen`, to make sure `setInitialValues` is not called again when screen is recomposed (for example, when rotating the screen).
- Also removed the `Scaffold` annotation from `SubscriptionSettingsUseCase`, because otherwise it was being shared among used instances, and state was moving around between screens.

### Checklist

- [x] The PR has a proper title, description and label.
- [x] I have [self-reviewed the PR](https://patrickdinh.medium.com/review-your-own-pull-requests-5634cad10b7a).
- [x] I have added documentation to complex functions and functions that can be used by other modules.
- [x] I have added reasonable tests or consciously decided to not add tests.
