### PR TITLE
Include fastlane metadata in Transifex config

### DIFF
--- a/.tx/config
+++ b/.tx/config
@@ -8,3 +8,24 @@ source_file  = app/src/main/res/values/strings.xml
 source_lang  = en
 type         = ANDROID
 minimum_perc = 0
+
+
+# Attention: fastlane directories are like "en-us", not "en-rUS"!
+
+[o:bitfireAT:p:icsx5:r:short-description]
+file_filter   = fastlane/metadata/android/<lang>/short_description.txt
+source_file   = fastlane/metadata/android/en-US/short_description.txt
+source_lang   = en
+type          = TXT
+minimum_perc  = 100
+resource_name = Metadata: short description
+lang_map = pl_PL: pl-PL, pt_BR: pt-BR, pt_PT: pt-PT, ru_UA: ru-UA, uk_UA: uk-UA
+
+[o:bitfireAT:p:icsx5:r:full-description]
+file_filter   = fastlane/metadata/android/<lang>/full_description.txt
+source_file   = fastlane/metadata/android/en-US/full_description.txt
+source_lang   = en
+type          = TXT
+minimum_perc  = 100
+resource_name = Metadata: Full description
+lang_map = pl_PL: pl-PL, pt_BR: pt-BR, pt_PT: pt-PT, ru_UA: ru-UA, uk_UA: uk-UA


### PR DESCRIPTION
### Purpose

At some point, Fastlane metadata was removed from the Transifex config.

### Short description

Add the resources back again, including the mapping to make sure `r` is not included in the lang codes.

### Checklist

- [x] The PR has a proper title, description and label.
- [x] I have [self-reviewed the PR](https://patrickdinh.medium.com/review-your-own-pull-requests-5634cad10b7a).
- [x] I have added documentation to complex functions and functions that can be used by other modules.
- [x] I have added reasonable tests or consciously decided to not add tests.
