### PR TITLE
Fix event retaining

### DIFF
--- a/app/src/main/java/at/bitfire/icsdroid/calendar/LocalCalendar.kt
+++ b/app/src/main/java/at/bitfire/icsdroid/calendar/LocalCalendar.kt
@@ -49,24 +49,24 @@ class LocalCalendar private constructor(
     }
 
     fun queryByUID(uid: String) =
-        queryEvents("${Events._SYNC_ID}=?", arrayOf(uid))
+        queryEvents("${Events.UID_2445}=?", arrayOf(uid))
 
     fun retainByUID(uids: MutableSet<String>): Int {
         var deleted = 0
         try {
             provider.query(
                 Events.CONTENT_URI.asSyncAdapter(account),
-                arrayOf(Events._ID, Events._SYNC_ID, Events.ORIGINAL_SYNC_ID),
+                arrayOf(Events._ID, Events.UID_2445),
                 "${Events.CALENDAR_ID}=? AND ${Events.ORIGINAL_SYNC_ID} IS NULL", arrayOf(id.toString()), null
             )?.use { row ->
                 while (row.moveToNext()) {
                     val eventId = row.getLong(0)
-                    val syncId = row.getString(1)
-                    if (!uids.contains(syncId)) {
+                    val uid = row.getString(1)
+                    if (!uids.contains(uid)) {
                         provider.delete(ContentUris.withAppendedId(Events.CONTENT_URI, eventId).asSyncAdapter(account), null, null)
                         deleted++
 
-                        uids -= syncId
+                        uids -= uid
                     }
                 }
             }


### PR DESCRIPTION
### Purpose

After #782, events are no longer retained. `_SYNC_ID` is set to null, and therefore all added events are removed when calling `retainByUID`. This is caused by synctools using `UID_2445` instead of `_SYNC_ID`.

See: https://developer.android.com/reference/android/provider/CalendarContract.EventsColumns#UID_2445

### Short description

- Replaced usages of `Events._SYNC_ID` with `Events.UID_2445`.

### Checklist

- [x] The PR has a proper title, description and label.
- [x] I have [self-reviewed the PR](https://patrickdinh.medium.com/review-your-own-pull-requests-5634cad10b7a).
- [x] I have added documentation to complex functions and functions that can be used by other modules.
- [x] I have added reasonable tests or consciously decided to not add tests.
