### PR TITLE
fix: treat HTTP 301 as permanent redirect

### DIFF
--- a/app/src/androidTest/java/at/bitfire/icsdroid/CalendarFetcherTest.kt
+++ b/app/src/androidTest/java/at/bitfire/icsdroid/CalendarFetcherTest.kt
@@ -160,6 +160,30 @@ class CalendarFetcherTest {
     }
 
     @Test
+    fun testFetchNetwork_onRedirectMovedPermanently_callsOnNewPermanentUrl() {
+        // 301 Moved Permanently must be treated like 308 Permanent Redirect
+        MockServer.enqueue(
+            status = HttpStatusCode.MovedPermanently,
+            headers = headers {
+                append(HttpHeaders.Location, MockServer.uri("new-location").toString())
+            }
+        )
+        MockServer.enqueue(content = "icalCorrect", status = HttpStatusCode.OK)
+
+        var newPermanentUrl: Uri? = null
+        val fetcher = object: CalendarFetcher(appContext, MockServer.uri(), client) {
+            override suspend fun onNewPermanentUrl(target: Uri) {
+                newPermanentUrl = target
+            }
+        }
+        runBlocking {
+            fetcher.fetch()
+        }
+
+        assertEquals(MockServer.uri("new-location"), newPermanentUrl)
+    }
+
+    @Test
     fun testFetchNetwork_onRedirectWithoutLocation() {
         MockServer.enqueue(status = HttpStatusCode.TemporaryRedirect)
 

--- a/app/src/main/java/at/bitfire/icsdroid/CalendarFetcher.kt
+++ b/app/src/main/java/at/bitfire/icsdroid/CalendarFetcher.kt
@@ -77,7 +77,7 @@ open class CalendarFetcher(
         if (!hasFollowedTempRedirect) {
             when (httpCode) {
                 // 301: Moved Permanently, 308: Permanent Redirect
-                HttpStatusCode.NotModified,
+                HttpStatusCode.MovedPermanently,
                 HttpStatusCode.PermanentRedirect ->
                     onNewPermanentUrl(target)
                 else ->


### PR DESCRIPTION
Treat HTTP 301 the same as 308 for permanent redirect handling when saving calendar URLs.

Fixes #824

## Test plan
- [ ] Review diff against issue
- [ ] Run project lint/tests if applicable
